### PR TITLE
Boot Knives

### DIFF
--- a/code/modules/clothing/rogueclothes/feet.dm
+++ b/code/modules/clothing/rogueclothes/feet.dm
@@ -28,7 +28,7 @@
 	armor = ARMOR_BOOTS_BAD
 
 /obj/item/clothing/shoes/roguetown/boots/attackby(obj/item/W, mob/living/carbon/user, params)
-	if(istype(W, /obj/item/rogueweapon/huntingknife/throwingknife))
+	if(istype(W, /obj/item/rogueweapon/huntingknife))
 		if(holdingknife == null)
 			for(var/obj/item/clothing/shoes/roguetown/boots/B in user.get_equipped_items(TRUE))
 				to_chat(loc, span_warning("I quickly slot [W] into [B]!"))


### PR DESCRIPTION
## About The Pull Request

I set out to add boot knives because it's kino, unbeknownst to be AP already had them, but only for throwing knives.
This fixes that. All daggers can now be put into boots by left clicking them with the weapon in hand. Right click the boots to retrieve.

## Testing Evidence
![image](https://github.com/user-attachments/assets/96f5f03b-7fbe-42e8-8577-188cc8ba2e50)

Booted, worked.

## Why It's Good For The Game

We love boot knives.
