### PR TITLE
less puking more stitching

### DIFF
--- a/code/datums/wounds/types/arteries.dm
+++ b/code/datums/wounds/types/arteries.dm
@@ -91,7 +91,7 @@
 		return
 	var/mob/living/carbon/carbon_owner = owner
 	if(!carbon_owner.stat && prob(5))
-		carbon_owner.vomit(1, blood = TRUE, stun = TRUE)
+		carbon_owner.vomit(1, blood = TRUE, stun = FALSE)
 
 /datum/wound/artery/reattachment
 	name = "replantation"

--- a/code/datums/wounds/types/arteries.dm
+++ b/code/datums/wounds/types/arteries.dm
@@ -6,7 +6,7 @@
 	sound_effect = 'sound/combat/crit.ogg'
 	whp = 50
 	sewn_whp = 20
-	bleed_rate = 20
+	bleed_rate = 10
 	sewn_bleed_rate = 0.2
 	clotting_threshold = null
 	sewn_clotting_threshold = null
@@ -44,7 +44,7 @@
 	crit_message = "Blood sprays from %VICTIM's throat!"
 	whp = 100
 	sewn_whp = 25
-	bleed_rate = 50
+	bleed_rate = 25
 	sewn_bleed_rate = 0.5
 	woundpain = 60
 	sewn_woundpain = 30
@@ -64,7 +64,7 @@
 	severity = WOUND_SEVERITY_FATAL
 	whp = 100
 	sewn_whp = 35
-	bleed_rate = 50
+	bleed_rate = 25
 	sewn_bleed_rate = 0.8
 	woundpain = 100
 	sewn_woundpain = 50
@@ -99,7 +99,7 @@
 	severity = WOUND_SEVERITY_FATAL
 	whp = 100
 	sewn_whp = 25
-	bleed_rate = 50
+	bleed_rate = 25
 	sewn_bleed_rate = 0.5
 	woundpain = 60
 	sewn_woundpain = 30

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -318,7 +318,7 @@
 	if(!stat)
 		if(prob(33) && getToxLoss() >= 75)
 			mob_timers["puke"] = world.time
-			vomit(1, blood = TRUE)
+			vomit(1, blood = TRUE, stun = FALSE)
 
 /mob/living/carbon/human/has_smoke_protection()
 	if(wear_mask)


### PR DESCRIPTION
## About The Pull Request
Makes puking blood not stun on most instances so you wont be interrupted every 0.1 seconds.
Reduces bleed rate of arteries, they are still a massive threat but you wont die in three seconds but maybe six instead.
## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Puking blood back to back for the smallest thing makes the already unfightable arteries and similiar even stupider to fight.
You might actually have time to flee or fix atleast one of your artery oopsies if you got out of the fight relatively quickly after the crit, or the people trying to patch you might have a bit longer to stitch you up too.