### PR TITLE
fill bottles/containers from fountain and taste more frequently

### DIFF
--- a/code/game/objects/structures/well.dm
+++ b/code/game/objects/structures/well.dm
@@ -83,3 +83,17 @@
 			playsound(user,pick('sound/items/drink_gen (1).ogg','sound/items/drink_gen (2).ogg','sound/items/drink_gen (3).ogg'), 100, TRUE)
 		return
 	..()
+
+/obj/structure/well/fountain/attackby(obj/item/I, mob/user, params)
+	if(istype(I, /obj/item/reagent_containers/glass))
+		var/obj/item/reagent_containers/glass/W = I
+		if(W.reagents.holder_full())
+			to_chat(user, span_warning("[W] is full."))
+			return
+		if(do_after(user, 30, target = src))
+			var/list/waterl = list(/datum/reagent/water = 100)
+			W.reagents.add_reagent_list(waterl)
+			to_chat(user, "<span class='notice'>I fill [W] from [src].</span>")
+			playsound(user, pick('sound/foley/waterwash (1).ogg','sound/foley/waterwash (2).ogg'), 80, FALSE)
+			return
+	else ..()

--- a/code/modules/mob/living/taste.dm
+++ b/code/modules/mob/living/taste.dm
@@ -16,7 +16,7 @@
 
 // non destructively tastes a reagent container
 /mob/living/proc/taste(datum/reagents/from)
-	if(last_taste_time + 50 < world.time)
+	if(last_taste_time + 10 < world.time)
 		var/taste_sensitivity = get_taste_sensitivity()
 		var/text_output = from.generate_taste_message(taste_sensitivity)
 		// We dont want to spam the same message over and over again at the


### PR DESCRIPTION
## About The Pull Request
Fill bottles from fountains cause it makes sense.
Taste delay is reduced so you wont be fooled by RNGing your berry's nutrients then eating the rest and getting 1000 stacks of poison, hopefully. If you eat it slow enough.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Convenience.