### PR TITLE
Reagent unfuckening

### DIFF
--- a/code/game/objects/items/rogueweapons/ranged/ammo.dm
+++ b/code/game/objects/items/rogueweapons/ranged/ammo.dm
@@ -214,7 +214,7 @@
 	ammo_type = /obj/item/ammo_casing/caseless/rogue/arrow/iron
 	range = 15
 	hitsound = 'sound/combat/hits/hi_arrow2.ogg'
-	poisontype = /datum/reagent/stampoison
+	poisontype = /datum/reagent/toxin/stampoison
 	poisonamount = 2
 	slur = 10
 	eyeblur = 10

--- a/code/game/objects/structures/well.dm
+++ b/code/game/objects/structures/well.dm
@@ -49,7 +49,7 @@
 			to_chat(user, span_warning("[W] is full."))
 			return
 		if(do_after(user, 30, target = src))
-			var/list/waterl = list(/datum/reagent/water = 50, /datum/reagent/organpoison = 50)
+			var/list/waterl = list(/datum/reagent/water = 50, /datum/reagent/toxin/stampoison = 50)
 			W.reagents.add_reagent_list(waterl)
 			to_chat(user, "<span class='notice'>I fill [W] from [src]. The water looks vile, am I really going to drink this?</span>")
 			playsound(user, pick('sound/foley/waterwash (1).ogg','sound/foley/waterwash (2).ogg'), 80, FALSE)

--- a/code/modules/farming/produce.dm
+++ b/code/modules/farming/produce.dm
@@ -202,8 +202,8 @@
 	seed = /obj/item/seeds/berryrogue/poison
 	icon_state = "berries"
 	tastes = list("berry" = 1)
-	list_reagents = list(/datum/reagent/berrypoison = 5, /datum/reagent/consumable/nutriment = 3, /datum/reagent/water = 5)
-	grind_results = list(/datum/reagent/berrypoison = 5)
+	list_reagents = list(/datum/reagent/toxin/berrypoison = 5, /datum/reagent/consumable/nutriment = 3, /datum/reagent/water = 5)
+	grind_results = list(/datum/reagent/toxin/berrypoison = 5)
 	color_index = "bad"
 
 /obj/item/reagent_containers/food/snacks/grown/nut
@@ -289,7 +289,7 @@
 	filling_color = "#008000"
 	bitesize_mod = 1
 	foodtype = VEGETABLES
-	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/berrypoison = 5)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/toxin/berrypoison = 5)
 	tastes = list("sweet" = 1,"bitterness" = 1)
 	eat_effect = /datum/status_effect/debuff/badmeal
 	rotprocess = 15 MINUTES
@@ -303,7 +303,7 @@
 	bitesize_mod = 1
 	foodtype = VEGETABLES
 	tastes = list("sweet" = 1,"bitterness" = 1)
-	list_reagents = list(/datum/reagent/drug/nicotine = 2, /datum/reagent/consumable/nutriment = 1, /datum/reagent/berrypoison = 5)
+	list_reagents = list(/datum/reagent/drug/nicotine = 2, /datum/reagent/consumable/nutriment = 1, /datum/reagent/toxin/berrypoison = 5)
 	grind_results = list(/datum/reagent/drug/nicotine = 5)
 	eat_effect = /datum/status_effect/debuff/badmeal
 	rotprocess = 15 MINUTES

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -6,6 +6,7 @@
 	description = "A toxic chemical."
 	color = "#CF3600" // rgb: 207, 54, 0
 	taste_description = "bitterness"
+	metabolization_rate = REAGENTS_METABOLISM * 0.5
 	taste_mult = 1.2
 	harmful = TRUE
 	var/toxpwr = 1.5

--- a/code/modules/roguetown/roguecrafting/alchemy.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy.dm
@@ -17,7 +17,7 @@
 	name = "ozium"
 	category = "Table"
 	result = list(/obj/item/reagent_containers/powder/ozium)
-	reqs = list(/obj/item/ash = 2, /datum/reagent/berrypoison = 2, /obj/item/reagent_containers/food/snacks/grown/rogue/sweetleafdry = 1)
+	reqs = list(/obj/item/ash = 2, /datum/reagent/toxin/berrypoison = 2, /obj/item/reagent_containers/food/snacks/grown/rogue/sweetleafdry = 1)
 	craftdiff = 2
 
 /datum/crafting_recipe/roguetown/alchemy/ozium_3x
@@ -26,14 +26,14 @@
 	result = list(/obj/item/reagent_containers/powder/ozium,
 					/obj/item/reagent_containers/powder/ozium,
 					/obj/item/reagent_containers/powder/ozium)
-	reqs = list(/obj/item/ash = 3, /datum/reagent/berrypoison = 3, /obj/item/reagent_containers/food/snacks/grown/rogue/sweetleafdry = 2)
+	reqs = list(/obj/item/ash = 3, /datum/reagent/toxin/berrypoison = 3, /obj/item/reagent_containers/food/snacks/grown/rogue/sweetleafdry = 2)
 	craftdiff = 3
 
 /datum/crafting_recipe/roguetown/alchemy/moon
 	name = "moondust"
 	category = "Table"
 	result = list(/obj/item/reagent_containers/powder/moondust)
-	reqs = list(/obj/item/ash = 2, /obj/item/reagent_containers/food/snacks/grown/rogue/pipeweeddry = 1, /datum/reagent/berrypoison = 2)
+	reqs = list(/obj/item/ash = 2, /obj/item/reagent_containers/food/snacks/grown/rogue/pipeweeddry = 1, /datum/reagent/toxin/berrypoison = 2)
 	craftdiff = 2
 
 /datum/crafting_recipe/roguetown/alchemy/moon_3x
@@ -43,7 +43,7 @@
 					/obj/item/reagent_containers/powder/moondust,
 					/obj/item/reagent_containers/powder/moondust
 				)
-	reqs = list(/obj/item/ash = 3, /obj/item/reagent_containers/food/snacks/grown/rogue/pipeweeddry = 2, /datum/reagent/berrypoison = 3)
+	reqs = list(/obj/item/ash = 3, /obj/item/reagent_containers/food/snacks/grown/rogue/pipeweeddry = 2, /datum/reagent/toxin/berrypoison = 3)
 	craftdiff = 3
 
 /datum/crafting_recipe/roguetown/alchemy/salt

--- a/code/modules/roguetown/roguecrafting/alchemy/alch_cauldron_recipes.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/alch_cauldron_recipes.dm
@@ -12,25 +12,25 @@
 	name = "Poison (Berry)"
 	smells_like = "death"
 	skill_required = SKILL_LEVEL_JOURNEYMAN // Basic poison should be harder to handle
-	output_reagents = list(/datum/reagent/berrypoison = 81)
+	output_reagents = list(/datum/reagent/toxin/berrypoison = 81)
 
 /datum/alch_cauldron_recipe/doompoison
 	name = "Poison (Doom)"
 	smells_like = "doom"
 	skill_required = SKILL_LEVEL_EXPERT // Strong poison should be more difficult to make
-	output_reagents = list(/datum/reagent/berrypoison = 81,/datum/reagent/additive = 81)
+	output_reagents = list(/datum/reagent/toxin/berrypoison = 81,/datum/reagent/additive = 81)
 
 /datum/alch_cauldron_recipe/stam_poison
 	name = "Stamina Poison"
 	smells_like = "a slow breeze"
 	skill_required = SKILL_LEVEL_JOURNEYMAN // Basic poison should be harder to handle
-	output_reagents = list(/datum/reagent/stampoison = 81)
+	output_reagents = list(/datum/reagent/toxin/stampoison = 81)
 
 /datum/alch_cauldron_recipe/big_stam_poison
 	name = "Stamina Poison (Strong)"
 	smells_like = "stagnant air"
 	skill_required = SKILL_LEVEL_EXPERT // Strong poison should be more difficult to make
-	output_reagents = list(/datum/reagent/stampoison = 81,/datum/reagent/additive = 81)
+	output_reagents = list(/datum/reagent/toxin/stampoison = 81,/datum/reagent/additive = 81)
 
 //Healing potions
 /datum/alch_cauldron_recipe/health_potion

--- a/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
@@ -4,6 +4,58 @@
 	reagent_state = LIQUID
 
 //Potions
+
+/datum/reagent/medicine/minorhealthpot
+	name = "Lesser Health Potion"
+	description = "Somewhat regenerates all types of damage."
+	reagent_state = LIQUID
+	color = "#ff9494"
+	taste_description = "tangy sweetness"
+	overdose_threshold = 0
+	metabolization_rate = 1 * REAGENTS_METABOLISM
+	alpha = 173
+
+/datum/reagent/medicine/minorhealthpot/on_mob_life(mob/living/carbon/M) // Heals half as much as health potion, but not wounds.
+	var/list/wCount = M.get_wounds()
+	if(M.blood_volume < BLOOD_VOLUME_NORMAL) //can not overfill
+		M.blood_volume = min(M.blood_volume+20, BLOOD_VOLUME_MAXIMUM)
+	if(wCount.len > 0 && prob(50)) //half as effective as a normal health pot but still heals wounds.
+		M.heal_wounds(10)
+		M.update_damage_overlays()
+		if(prob(10))
+			to_chat(M, span_nicegreen("I feel my wounds mending."))
+	for(var/datum/reagent/toxin/R in M.reagents.reagent_list)
+		if(R != src)
+			M.reagents.remove_reagent(R.type,1)
+	M.adjustBruteLoss(-0.5, 0) // 20u = 25 points of healing
+	M.adjustFireLoss(-0.5, 0)
+	M.adjustToxLoss(-0.5, 0)
+	M.adjustOxyLoss(-1.5, 0)
+	M.adjustCloneLoss(-1, 0)
+	M.adjustOrganLoss(ORGAN_SLOT_LUNGS, -1)
+	M.adjustOrganLoss(ORGAN_SLOT_HEART, -1)
+	M.adjustOrganLoss(ORGAN_SLOT_TONGUE, -1)
+	M.adjustOrganLoss(ORGAN_SLOT_EARS, -1)
+	M.adjustOrganLoss(ORGAN_SLOT_EYES, -1)
+	M.adjustOrganLoss(ORGAN_SLOT_LIVER, -1)
+	M.adjustOrganLoss(ORGAN_SLOT_APPENDIX, -1)
+	M.adjustOrganLoss(ORGAN_SLOT_STOMACH, -1)
+	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, -1)
+	..()
+	. = 1
+
+/datum/chemical_reaction/minorpot
+	name = "Lesser Health Potion"
+	id = /datum/reagent/medicine/minorhealthpot
+	results = list(/datum/reagent/medicine/minorhealthpot = 10)
+	required_reagents = list(/datum/reagent/medicine/healthpot = 5, /datum/reagent/water = 5)
+
+/datum/chemical_reaction/minorpot
+	name = "Health Potion"
+	id = /datum/reagent/medicine/healthpot
+	results = list(/datum/reagent/medicine/healthpot = 10)
+	required_reagents = list(/datum/reagent/medicine/stronghealth = 5, /datum/reagent/water = 5)
+
 /datum/reagent/medicine/healthpot
 	name = "Health Potion"
 	description = "Gradually regenerates all types of damage."
@@ -15,20 +67,37 @@
 	alpha = 173
 
 /datum/reagent/medicine/healthpot/on_mob_life(mob/living/carbon/M)
-	if(volume >= 60)
-		M.reagents.remove_reagent(/datum/reagent/medicine/healthpot, 2) //No overhealing.
-	if(M.blood_volume < BLOOD_VOLUME_NORMAL)
-		M.blood_volume = min(M.blood_volume+20, BLOOD_VOLUME_MAXIMUM)
 	var/list/wCount = M.get_wounds()
+	if(M.blood_volume < BLOOD_VOLUME_NORMAL)
+		M.blood_volume = min(M.blood_volume+50, BLOOD_VOLUME_MAXIMUM)
+	else
+		//can overfill you with blood, but at a slower rate
+		M.blood_volume = min(M.blood_volume+10, BLOOD_VOLUME_MAXIMUM)
 	if(wCount.len > 0)
-		M.heal_wounds(3) //at a motabalism of .5 U a tick this translates to 120WHP healing with 20 U Most wounds are unsewn 15-100. This is powerful on single wounds but rapidly weakens at multi wounds.
-	if(volume > 0.99)
-		M.adjustBruteLoss(-1.75*REM, 0)
-		M.adjustFireLoss(-1.75*REM, 0)
-		M.adjustOxyLoss(-1.25, 0)
-		M.adjustOrganLoss(ORGAN_SLOT_BRAIN, -5*REM)
-		M.adjustCloneLoss(-1.75*REM, 0)
+		//some peeps dislike the church, this allows an alternative thats not a doctor or sleep.
+		M.heal_wounds(20)
+		M.update_damage_overlays()
+		if(prob(10))
+			to_chat(M, span_nicegreen("I feel my wounds mending."))
+	for(var/datum/reagent/toxin/R in M.reagents.reagent_list)
+		if(R != src)
+			M.reagents.remove_reagent(R.type,2)
+	M.adjustBruteLoss(-1, 0) // 20u = 50 points of healing
+	M.adjustFireLoss(-1, 0)
+	M.adjustToxLoss(-1, 0)
+	M.adjustOxyLoss(-3, 0)
+	M.adjustCloneLoss(-2, 0)
+	M.adjustOrganLoss(ORGAN_SLOT_LUNGS, -2)
+	M.adjustOrganLoss(ORGAN_SLOT_HEART, -2)
+	M.adjustOrganLoss(ORGAN_SLOT_TONGUE, -2)
+	M.adjustOrganLoss(ORGAN_SLOT_EARS, -2)
+	M.adjustOrganLoss(ORGAN_SLOT_EYES, -2)
+	M.adjustOrganLoss(ORGAN_SLOT_LIVER, -2)
+	M.adjustOrganLoss(ORGAN_SLOT_APPENDIX, -2)
+	M.adjustOrganLoss(ORGAN_SLOT_STOMACH, -2)
+	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, -2)
 	..()
+	. = 1
 
 /datum/reagent/medicine/stronghealth
 	name = "Strong Health Potion"
@@ -38,22 +107,33 @@
 	metabolization_rate = REAGENTS_METABOLISM * 3
 
 /datum/reagent/medicine/stronghealth/on_mob_life(mob/living/carbon/M)
-	if(volume >= 60)
-		M.reagents.remove_reagent(/datum/reagent/medicine/healthpot, 2) //No overhealing.
-	if(M.blood_volume < BLOOD_VOLUME_NORMAL)
-		M.blood_volume = min(M.blood_volume+80, BLOOD_VOLUME_MAXIMUM)
-	else
-		//can overfill you with blood, but at a slower rate
-		M.blood_volume = min(M.blood_volume+10, BLOOD_VOLUME_MAXIMUM)
 	var/list/wCount = M.get_wounds()
+	if(M.blood_volume < BLOOD_VOLUME_NORMAL)
+		M.blood_volume = min(M.blood_volume+100, BLOOD_VOLUME_MAXIMUM)
+	else
+		M.blood_volume = min(M.blood_volume+20, BLOOD_VOLUME_MAXIMUM)
 	if(wCount.len > 0)
-		M.heal_wounds(6) //at a motabalism of .5 U a tick this translates to 240WHP healing with 20 U Most wounds are unsewn 15-100.
-	if(volume > 0.99)
-		M.adjustBruteLoss(-7*REM, 0)
-		M.adjustFireLoss(-7*REM, 0)
-		M.adjustOxyLoss(-5, 0)
-		M.adjustOrganLoss(ORGAN_SLOT_BRAIN, -5*REM)
-		M.adjustCloneLoss(-7*REM, 0)
+		M.heal_wounds(30)
+		M.update_damage_overlays()
+		if(prob(10))
+			to_chat(M, span_nicegreen("I feel my wounds mending."))
+	for(var/datum/reagent/toxin/R in M.reagents.reagent_list)
+		if(R != src)
+			M.reagents.remove_reagent(R.type,3)
+	M.adjustBruteLoss(-1.5, 0) // 20u = 150 points of healing.
+	M.adjustFireLoss(-1.5, 0)
+	M.adjustToxLoss(-1.5, 0)
+	M.adjustOxyLoss(-5, 0)
+	M.adjustCloneLoss(-3, 0)
+	M.adjustOrganLoss(ORGAN_SLOT_LUNGS, -3)
+	M.adjustOrganLoss(ORGAN_SLOT_HEART, -3)
+	M.adjustOrganLoss(ORGAN_SLOT_TONGUE, -3)
+	M.adjustOrganLoss(ORGAN_SLOT_EARS, -3)
+	M.adjustOrganLoss(ORGAN_SLOT_EYES, -3)
+	M.adjustOrganLoss(ORGAN_SLOT_LIVER, -3)
+	M.adjustOrganLoss(ORGAN_SLOT_APPENDIX, -3)
+	M.adjustOrganLoss(ORGAN_SLOT_STOMACH, -3)
+	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, -3)
 	..()
 	. = 1
 

--- a/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
@@ -131,10 +131,8 @@
 /datum/reagent/medicine/antidote/on_mob_life(mob/living/carbon/M)
 	if(volume > 0.99)
 		M.adjustToxLoss(-4, 0)
-	for(var/datum/reagent/R in M.reagents.reagent_list)
-		if(R.harmful)
-			holder.remove_reagent(R.type, 1)
-
+	for(var/datum/reagent/toxin/R in M.reagents.reagent_list)
+		holder.remove_reagent(R.type, 1)
 	..()
 	. = 1
 
@@ -258,36 +256,25 @@ still is dangerous. Toxloss of 3 at metabolism 0.1 puts you in dying early stage
 A dose of ingested potion is defined as 5u, projectile deliver at most 2u, you already do damage with projectile, a bolt can only feasible hold a tiny amount of poison, so much easier to deliver than ingested and so on.
 If you want to expand on poisons theres tons of fun effects TG chemistry has that could be added, randomzied damage values for more unpredictable poison, add trait based resists instead of the clunky race check etc.*/
 
-/datum/reagent/berrypoison	// Weaker poison, balanced to make you wish for death and incapacitate but not kill
+/datum/reagent/toxin/berrypoison	// Weaker poison, balanced to make you wish for death and incapacitate but not kill
 	name = "Berry Poison"
 	description = ""
 	reagent_state = LIQUID
 	color = "#47b2e0"
 	taste_description = "bitterness"
-	metabolization_rate = 0.1 * REAGENTS_METABOLISM
-	harmful = TRUE
 
-/datum/reagent/berrypoison/on_mob_life(mob/living/carbon/M)
-	if(volume > 0.09)
-		if(isdwarf(M))
-			M.add_nausea(1)
-			M.adjustToxLoss(0.5)
-		else
-			M.add_nausea(3) // so one berry or one dose (one clunk of extracted poison, 5u) will make you really sick and a hair away from crit.
-			M.adjustToxLoss(2)
-	return ..()
+/datum/reagent/toxin/berrypoison/on_mob_life(mob/living/carbon/M)
+	if(!HAS_TRAIT(M, TRAIT_NASTY_EATER))
+		return ..()
 
-
-/datum/reagent/strongpoison		// Strong poison, meant to be somewhat difficult to produce using alchemy or spawned with select antags. Designed to kill in one full dose (5u) better drink antidote fast
+/datum/reagent/toxin/strongpoison		// Strong poison, meant to be somewhat difficult to produce using alchemy or spawned with select antags. Designed to kill in one full dose (5u) better drink antidote fast
 	name = "Strong Poison"
 	description = ""
 	reagent_state = LIQUID
 	color = "#1a1616"
 	taste_description = "burning"
-	metabolization_rate = 0.1 * REAGENTS_METABOLISM
-	harmful = TRUE
 
-/datum/reagent/strongpoison/on_mob_life(mob/living/carbon/M)
+/datum/reagent/toxin/strongpoison/on_mob_life(mob/living/carbon/M)
 	testing("Someone was poisoned")
 	if(volume > 0.09)
 		if(isdwarf(M))
@@ -298,64 +285,54 @@ If you want to expand on poisons theres tons of fun effects TG chemistry has tha
 			M.adjustToxLoss(4.5) // just enough so 5u will kill you dead with no help
 	return ..()
 
-/datum/reagent/organpoison
+/datum/reagent/toxin/organpoison
 	name = "Organ Poison"
 	description = ""
 	reagent_state = LIQUID
 	color = "#2c1818"
 	taste_description = "sour meat"
-	metabolization_rate = 0.1 * REAGENTS_METABOLISM
-	harmful = TRUE
 
+/datum/reagent/toxin/organpoison/on_mob_life(mob/living/carbon/M)
+	if(!HAS_TRAIT(M, TRAIT_NASTY_EATER) && !HAS_TRAIT(M, TRAIT_ORGAN_EATER) && !HAS_TRAIT(M, TRAIT_WILD_EATER))
+		return ..()
 
-/datum/reagent/organpoison/on_mob_life(mob/living/carbon/M)
-	if(!HAS_TRAIT(M, TRAIT_NASTY_EATER) && !HAS_TRAIT(M, TRAIT_ORGAN_EATER))
-		M.add_nausea(9)
-		M.adjustToxLoss(2)
-	return ..()
-
-/datum/reagent/stampoison
+/datum/reagent/toxin/stampoison
 	name = "Stamina Poison"
 	description = ""
 	reagent_state = LIQUID
 	color = "#083b1c"
 	taste_description = "breathlessness"
-	metabolization_rate = 0.1 * REAGENTS_METABOLISM * 3
-	harmful = TRUE
+	metabolization_rate = 0.5 * REAGENTS_METABOLISM * 3
+	toxpwr = 0
 
 
-/datum/reagent/stampoison/on_mob_life(mob/living/carbon/M)
+/datum/reagent/toxin/stampoison/on_mob_life(mob/living/carbon/M)
 	if(!HAS_TRAIT(M,TRAIT_NOROGSTAM))
 		M.rogstam_add(-45) //Slowly leech stamina
 	return ..()
 
-/datum/reagent/strongstampoison
+/datum/reagent/toxin/strongstampoison
 	name = "Strong Stamina Poison"
 	description = ""
 	reagent_state = LIQUID
 	color = "#041d0e"
 	taste_description = "frozen air"
-	metabolization_rate = 0.1 * REAGENTS_METABOLISM * 9
-	harmful = TRUE
+	metabolization_rate = 0.5 * REAGENTS_METABOLISM * 9
+	toxpwr = 0
 
 
-/datum/reagent/strongstampoison/on_mob_life(mob/living/carbon/M)
+/datum/reagent/toxin/strongstampoison/on_mob_life(mob/living/carbon/M)
 	if(!HAS_TRAIT(M,TRAIT_NOROGSTAM))
 		M.rogstam_add(-180) //Rapidly leech stamina
 	return ..()
 
 /datum/reagent/toxin/killersice
 	name = "Killer's Ice"
-	description = "c8c9e9"
+	description = ""
 	reagent_state = LIQUID
-	color = "#FFFFFF"
-	metabolization_rate = 0.1
-	toxpwr = 0
-	harmful = TRUE
-
-/datum/reagent/toxin/killersice/on_mob_life(mob/living/carbon/M)
-	M.adjustToxLoss(10, 0)
-	return ..()
+	color = "#c8c9e9"
+	taste_description = "cold needles"
+	toxpwr = 10
 
 //Potion reactions
 /datum/chemical_reaction/alch/stronghealth
@@ -381,16 +358,16 @@ If you want to expand on poisons theres tons of fun effects TG chemistry has tha
 
 /datum/chemical_reaction/alch/strongpoison
 	name = "Strong Health Poison"
-	id = /datum/reagent/strongpoison
-	results = list(/datum/reagent/strongpoison = 1)
-	required_reagents = list(/datum/reagent/berrypoison = 1, /datum/reagent/additive = 1)
+	id = /datum/reagent/toxin/strongpoison
+	results = list(/datum/reagent/toxin/strongpoison = 1)
+	required_reagents = list(/datum/reagent/toxin/berrypoison = 1, /datum/reagent/additive = 1)
 	mix_message = "The cauldron glows for a moment."
 
 /datum/chemical_reaction/alch/strongstampoison
 	name = "Strong Stamina Leech Potion"
-	id = /datum/reagent/strongstampoison
-	results = list(/datum/reagent/strongstampoison = 1)
-	required_reagents = list(/datum/reagent/stampoison = 1, /datum/reagent/additive = 1)
+	id = /datum/reagent/toxin/strongstampoison
+	results = list(/datum/reagent/toxin/strongstampoison = 1)
+	required_reagents = list(/datum/reagent/toxin/stampoison = 1, /datum/reagent/additive = 1)
 	mix_message = "The cauldron glows for a moment."
 
 
@@ -412,7 +389,6 @@ If you want to expand on poisons theres tons of fun effects TG chemistry has tha
 	reagent_state = LIQUID
 	color = "#ffc400"
 	metabolization_rate = 0.5
-	harmful = TRUE
 
 /datum/reagent/toxin/fyritiusnectar/on_mob_life(mob/living/carbon/M)
 	if(volume > 0.49)

--- a/code/modules/roguetown/roguecrafting/crafting/ammo_and_ranged.dm
+++ b/code/modules/roguetown/roguecrafting/crafting/ammo_and_ranged.dm
@@ -125,7 +125,7 @@
     result = /obj/item/ammo_casing/caseless/rogue/arrow/poison
     reqs = list(
                 /obj/item/ammo_casing/caseless/rogue/arrow/iron = 1,
-                /datum/reagent/stampoison = 5
+                /datum/reagent/toxin/stampoison = 5
                 )
     req_table = TRUE
 
@@ -135,7 +135,7 @@
     result = /obj/item/ammo_casing/caseless/rogue/arrow/stone/poison
     reqs = list(
                 /obj/item/ammo_casing/caseless/rogue/arrow/stone = 1,
-                /datum/reagent/stampoison = 5
+                /datum/reagent/toxin/stampoison = 5
                 )
     req_table = TRUE
 
@@ -151,7 +151,7 @@
         )
     reqs = list(
         /obj/item/ammo_casing/caseless/rogue/arrow/iron = 5,
-        /datum/reagent/berrypoison = 25,
+        /datum/reagent/toxin/berrypoison = 25,
         )
 
     req_table = TRUE
@@ -168,7 +168,7 @@
         )
     reqs = list(
         /obj/item/ammo_casing/caseless/rogue/arrow/stone = 5,
-        /datum/reagent/berrypoison = 25,
+        /datum/reagent/toxin/berrypoison = 25,
         )
 
     req_table = TRUE

--- a/code/modules/roguetown/roguejobs/alchemist/container.dm
+++ b/code/modules/roguetown/roguejobs/alchemist/container.dm
@@ -31,16 +31,16 @@
 	list_reagents = list(/datum/reagent/medicine/strong_antidote = 48)
 
 /obj/item/reagent_containers/glass/bottle/rogue/berrypoison
-	list_reagents = list(/datum/reagent/berrypoison = 15)
+	list_reagents = list(/datum/reagent/toxin/berrypoison = 15)
 
 /obj/item/reagent_containers/glass/bottle/rogue/strongpoison
-	list_reagents = list(/datum/reagent/strongpoison = 15)
+	list_reagents = list(/datum/reagent/toxin/strongpoison = 15)
 
 /obj/item/reagent_containers/glass/bottle/rogue/stampoison
-	list_reagents = list(/datum/reagent/stampoison = 15)
+	list_reagents = list(/datum/reagent/toxin/stampoison = 15)
 
 /obj/item/reagent_containers/glass/bottle/rogue/strongstampoison
-	list_reagents = list(/datum/reagent/strongstampoison = 15)
+	list_reagents = list(/datum/reagent/toxin/strongstampoison = 15)
 
 /obj/item/reagent_containers/glass/bottle/alchemical/strpot
 	list_reagents = list(/datum/reagent/buff/strength = 27)

--- a/code/modules/roguetown/roguejobs/alchemist/container.dm
+++ b/code/modules/roguetown/roguejobs/alchemist/container.dm
@@ -2,6 +2,9 @@
 /obj/item/reagent_containers/glass/bottle/rogue/healthpot
 	list_reagents = list(/datum/reagent/medicine/healthpot = 48)
 
+/obj/item/reagent_containers/glass/bottle/rogue/minorhealthpot
+	list_reagents = list(/datum/reagent/medicine/minorhealthpot = 45)
+
 /obj/item/reagent_containers/glass/bottle/rogue/healthpotnew
 	list_reagents = list(/datum/reagent/medicine/stronghealth = 48)
 

--- a/code/modules/roguetown/roguestock/import.dm
+++ b/code/modules/roguetown/roguestock/import.dm
@@ -57,6 +57,21 @@
 	new /obj/item/rogueweapon/mace/cudgel(src)
 	new /obj/item/rope/chain(src)
 
+/datum/roguestock/import/redpotionweak
+	name = "Crate of Lesser Health Potions"
+	desc = "Red that MIGHT keep men alive, on a budget."
+	item_type = /obj/structure/closet/crate/chest/steward/redpotionweak
+	export_price = 50
+	importexport_amt = 1
+
+/obj/structure/closet/crate/chest/steward/redpotionweak/Initialize()
+	. = ..()
+	new /obj/item/reagent_containers/glass/bottle/rogue/minorhealthpot(src)
+	new /obj/item/reagent_containers/glass/bottle/rogue/minorhealthpot(src)
+	new /obj/item/reagent_containers/glass/bottle/rogue/minorhealthpot(src)
+	new /obj/item/reagent_containers/glass/bottle/rogue/minorhealthpot(src)
+	new /obj/item/reagent_containers/glass/bottle/rogue/minorhealthpot(src)
+
 /datum/roguestock/import/redpotion
 	name = "Crate of Health Potions"
 	desc = "Red that keeps men alive."

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -150,7 +150,7 @@
 	name = "appendix"
 	icon_state = "appendix"
 	icon = 'icons/obj/surgery.dmi'
-	list_reagents = list(/datum/reagent/consumable/nutriment = 5, /datum/reagent/organpoison = 1)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 5, /datum/reagent/toxin/organpoison = 1)
 	foodtype = RAW | MEAT | GROSS
 	eat_effect = /datum/status_effect/debuff/uncookedfood
 	var/obj/item/organ/organ_inside
@@ -174,8 +174,8 @@
 	return
 
 /obj/item/reagent_containers/food/snacks/organ/heart
-	list_reagents = list(/datum/reagent/consumable/nutriment = 6, /datum/reagent/organpoison = 2)
-	grind_results = list(/datum/reagent/organpoison = 6)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 6, /datum/reagent/toxin/stampoison = 2)
+	grind_results = list(/datum/reagent/toxin/stampoison = 6)
 
 /obj/item/reagent_containers/food/snacks/organ/heart/check_culling(mob/living/eater)
 	. = ..()

--- a/modular/Creechers/code/trufflepig.dm
+++ b/modular/Creechers/code/trufflepig.dm
@@ -65,7 +65,7 @@
 	name = "truffles"
 	icon = 'icons/obj/hydroponics/harvest.dmi'
 	icon_state = "mushroom1_full"
-	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/berrypoison = 5)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/toxin/berrypoison = 5)
 	cooked_type = /obj/item/reagent_containers/food/snacks/rogue/toxicshrooms/cooked
 	fried_type = /obj/item/reagent_containers/food/snacks/rogue/toxicshrooms/cooked
 	color = "#ab7d6f"

--- a/modular/Neu_Food/code/cooked/cooked_pastry.dm
+++ b/modular/Neu_Food/code/cooked/cooked_pastry.dm
@@ -92,7 +92,7 @@
 	tastes = list("berry" = 1)
 
 /obj/item/reagent_containers/food/snacks/rogue/foodbase/handpieraw/poison
-	list_reagents = list(/datum/reagent/berrypoison = 5)
+	list_reagents = list(/datum/reagent/toxin/berrypoison = 5)
 	w_class = WEIGHT_CLASS_NORMAL
 	foodtype = GRAIN | FRUIT
 	tastes = list("bitter berry" = 1)

--- a/modular/Neu_Food/code/cooked/cooked_pies.dm
+++ b/modular/Neu_Food/code/cooked/cooked_pies.dm
@@ -118,7 +118,7 @@
 	name = "berry pie"
 	desc = "A delicious, homemade pie made with wild berries. Still needs to be sliced."
 	slices_num = 4
-	list_reagents = list(/datum/reagent/consumable/nutriment = MEAL_GOOD, /datum/reagent/berrypoison = 12)
+	list_reagents = list(/datum/reagent/consumable/nutriment = MEAL_GOOD, /datum/reagent/toxin/berrypoison = 12)
 	tastes = list("crispy butterdough" = 1, "bitter berries" =1)
 	filling_color = "#4a62cf"
 


### PR DESCRIPTION
## About The Pull Request
Properly parents toxins to toxin parent, and metabolize is set right to 0.5 of standard metabolization as it likely shoulda been.
Makes health potions actually effective and close wounds instead of do stupid ass raw point healing which is actually doing nothing in roguetown code since you can only die to decaps and blood loss from wounds.
Adds lesser health potions for half the price that can be ordered by the steward or diluted from normal potions.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Toxins are less slop coded, and metabolize properly so you wont shit and die by a single berry bite etc.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
