### PR TITLE
Zer0 music laginator

### DIFF
--- a/code/modules/droning/droning.dm
+++ b/code/modules/droning/droning.dm
@@ -30,11 +30,15 @@ SUBSYSTEM_DEF(droning)
 	play_area_sound(area_entered, entering)
 
 /datum/controller/subsystem/droning/proc/play_area_sound(area/area_player, client/listener)
-	if(!area_player || !listener)
+	if(!area_player || !listener || !area_player.we_droning_here || !area_player.droning_sound)
 		return
-	
+	if(listener?.prefs.musicvol <= 0)
+		return	
+	var/used_sound
+
 	if(SSticker.current_state >= GAME_STATE_FINISHED) //stop drones in round end
 		return
+	
 
 	if(area_player.we_droning_here)
 
@@ -83,7 +87,10 @@ SUBSYSTEM_DEF(droning)
 		return
 
 	var/frenq = 1
-
+	
+	if(dreamer?.prefs.musicvol <= 0)
+		return
+	
 	if(HAS_TRAIT(dreamer.mob, TRAIT_DRUQK))
 		frenq = -1
 
@@ -162,7 +169,10 @@ SUBSYSTEM_DEF(droning)
 	//kill the previous looping
 	kill_loop(dreamer)
 
-	var/amb_sound_list = null
+	if(dreamer?.prefs.musicvol <= 0)
+		return
+
+	var/loopsounds = null
 	if(area_entered.we_looping_here)
 		if(GLOB.tod == "night")
 			if(area_entered.ambientnight)
@@ -194,7 +204,10 @@ SUBSYSTEM_DEF(droning)
 		return
 	kill_rain(dreamer)
 
-	var/amb_sound_list = null
+	if(dreamer?.prefs.musicvol <= 0)
+		return
+
+	var/rainsounds = null
 	if(area_entered.ambientrain)
 		amb_sound_list = area_entered.ambientrain
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

If music is set to zero, it will no longer lag entering a new area because it won't try to load said music.

Credits: EvenInDeathIStillServe
PR: https://github.com/Tree445/Hearthstone/pull/445 

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

Entering new areas was quite annoying, especially when the game tries to load the music but the music preferences at set to zero, so, there was never a point to load it to begin with, regardless, this should ensure that combat moving from one area to the other will go more smoothly, there won't be a defenders advantage because the attacker had to load the new area music in first, there won't be all those, I lagged and ran into someone, fell in a pit, or got a few licks against me before I could react due to the game freezing.
---
When it comes to proof of testing, there was none done since it assumes it'll work by default if no conflicts spring up.