### PR TITLE
Update lightning_bolt.dm

### DIFF
--- a/code/modules/spells/spell_types/wizard/projectiles_single/lightning_bolt.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_single/lightning_bolt.dm
@@ -32,7 +32,7 @@
 	hitscan = TRUE
 	movement_type = UNSTOPPABLE
 	light_color = LIGHT_COLOR_WHITE
-	damage = 15
+	damage = 25
 	damage_type = BURN
 	accuracy = 40 // Base accuracy is lower for burn projectiles because they bypass armor
 	nodamage = FALSE
@@ -54,8 +54,6 @@
 			var/mob/living/L = target
 			if(L.STACON <= 14)
 				L.electrocute_act(2, src, 2, SHOCK_NOSTUN)
-				L.Paralyze(10)
 			else
 				L.electrocute_act(1, src, 1, SHOCK_NOSTUN)
-				L.Paralyze(10)
 	qdel(src)


### PR DESCRIPTION
## About The Pull Request

Removed paralyze from lightning bolt, buffs damage.

## Why It's Good For The Game

Mages having a magical spell that's hitscan and instantly floors you is absolutely not balanced nor will it ever be. In combat the moment you get knocked on the ground you're practically dead already and this has made it so much worse than it should be.
