### PR TITLE
Armorer's touch: reforged and reboiled.

### DIFF
--- a/code/__DEFINES/roguetown.dm
+++ b/code/__DEFINES/roguetown.dm
@@ -48,6 +48,7 @@
 #define ARMOR_HEAD_LEATHER list("blunt" = 90, "slash" = 60, "stab" = 30, "piercing" = 20, "fire" = 0, "acid" = 0)
 
 // Mask Armor
+#define ARMOR_MASK_EYEPATCH list("blunt" = 5, "slash" = 10, "stab" = 5, "piercing" = 2, "fire" = 0, "acid" = 0)
 #define ARMOR_MASK_METAL_BAD list("blunt" = 50, "slash" = 50, "stab" = 50, "piercing" = 50, "fire" = 0, "acid" = 0)
 #define ARMOR_MASK_METAL list("blunt" = 50, "slash" = 100, "stab" = 80, "piercing" = 50, "fire" = 0, "acid" = 0)
 

--- a/code/modules/clothing/rogueclothes/mask.dm
+++ b/code/modules/clothing/rogueclothes/mask.dm
@@ -59,17 +59,20 @@
 
 /obj/item/clothing/mask/rogue/eyepatch
 	name = "eyepatch"
-	desc = "An eyepatch, fitted for the right eye."
+	desc = "An eyepatch, fitted for the right eye, used by pirates and those with poked eyes, the patch itself makes parrying to perform on the blindspot"
 	icon_state = "eyepatch"
-	max_integrity = 20
+	max_integrity = 50
+	armor = ARMOR_MASK_EYEPATCH
+	body_parts_covered = RIGHT_EYE
 	integrity_failure = 0.5
 	block2add = FOV_RIGHT
 	body_parts_covered = EYES
 	sewrepair = TRUE
 
 /obj/item/clothing/mask/rogue/eyepatch/left
-	desc = "An eyepatch, fitted for the left eye."
+	desc = "An eyepatch, fitted for the left eye, used by pirates and those with poked eyes, the patch itself makes parrying to perform on the blindspot"
 	icon_state = "eyepatch_l"
+	body_parts_covered = LEFT_EYE
 	block2add = FOV_LEFT
 
 /obj/item/clothing/mask/rogue/lordmask
@@ -108,6 +111,7 @@
 
 /obj/item/clothing/mask/rogue/facemask
 	name = "iron mask"
+	desc = "An iron mask which protects the eyes, nose and mouth while also obscuring the face it."
 	icon_state = "imask"
 	max_integrity = 100
 	blocksound = PLATEHIT
@@ -134,12 +138,13 @@
 /obj/item/clothing/mask/rogue/facemask/copper
 	name = "copper mask"
 	icon_state = "cmask"
-	desc = "A heavy copper mask that conceals and protects the face, though not very effectively."
+	desc = "A heavy copper mask which protects the eyes, nose and mouth yet not all that effectively while also obscuring the face it."
 	armor = ARMOR_MASK_METAL_BAD
 	smeltresult = /obj/item/ingot/copper
 
 /obj/item/clothing/mask/rogue/facemask/hound
 	name = "hound mask"
+	desc = "An mask of iron with a shape of a hound's muzzle which protects the eyes, nose and mouth while also obscuring the face it."
 	icon_state = "imask_hound"
 	max_integrity = 100
 	blocksound = PLATEHIT
@@ -221,6 +226,7 @@
 
 /obj/item/clothing/mask/rogue/facemask/steel
 	name = "steel mask"
+	desc = "A mask of steel which protects the eyes, nose and mouth while also obscuring the face it."
 	icon_state = "smask"
 	max_integrity = 200
 	smeltresult = /obj/item/ingot/steel
@@ -233,11 +239,11 @@
 
 /obj/item/clothing/mask/rogue/facemask/steel/hound
 	name = "steel hound mask"
-	desc = "A steel mask, made for those who have snouts, protecting the eyes, nose and muzzle while obscuring the face."
+	desc = "A mask of steel with a shape of a hound's muzzle which protects the eyes, nose and mouth while also obscuring the face it."
 	icon_state = "smask_hound"
 
 /obj/item/clothing/mask/rogue/facemask/goldmask
-	name = "Gold Mask"
+	name = "gold mask"
 	icon_state = "goldmask"
 	max_integrity = 150
 	sellprice = 100
@@ -304,7 +310,7 @@
 /obj/item/clothing/mask/rogue/ragmask/ComponentInitialize()
 	AddComponent(/datum/component/adjustable_clothing, NECK, null, null, 'sound/foley/equip/rummaging-03.ogg', null, (UPD_HEAD|UPD_MASK))	//Standard mask
 
-/obj/item/clothing/mask/rogue/ragmask/red //predyed mask for NPCs
+/obj/item/clothing/mask/rogue/ragmask/red //pre-dyed mask for NPCs
 	color = CLOTHING_RED
 
 /obj/item/clothing/mask/rogue/lordmask/naledi


### PR DESCRIPTION
## About The Pull Request
In this present draft PR that has finished the mask portion of all possible things, aims to tweak and adjust both the smith-able and leather working versions, of armor either by changing their integrity or protection values, one thing is for certain some of them will get updated descriptions to better highlight their purpose, or just as nicer to read flavor text.
---
# Things done.
- ## Masks related
- The eyepatch
- Integrity 20 > 50.
- Added a new define on Armor Mask, ARMOR_MASK_EYEPATCH with protection of: blunt = 5, slash = 10, stab = 5, piercing = 2, fire/acid = 0. (It isn't much, but it's just enough to make it feel like it exists, keep in mind, wearing an eyepatch takes 2 parry angles away)
- Body part coverings for each eye and changed description from "An eyepatch, fitted for the left/right eye."
- Right version gained right eye protection with the description of "An eyepatch, fitted for the right eye, used by pirates and those with poked eyes, the patch itself makes parrying to perform on the blindspot"
- Left version gained left eye protection with the description "An eyepatch, fitted for the left eye, used by pirates and those with poked eyes, the patch itself makes parrying to perform on the blindspot"
---
- Copper mask
- Changed description from "A heavy copper mask that conceals and protects the face, though not very effectively." to "A heavy copper mask which protects the eyes, nose and mouth yet not all that effectively while also obscuring the face it."

- Iron mask.
- Added description "An iron mask which protects the eyes, nose and mouth while also obscuring the face it."

- Steel mask.
- Added description "A mask of steel which protects the eyes, nose and mouth while also obscuring the face it."

- Hound mask. (Iron)
- Added description "An mask of iron with a shape of a hound's muzzle which protects the eyes, nose and mouth while also obscuring the face it."

- Hound mask. (Steel)
- Changed description from "A steel mask, made for those who have snouts, protecting the eyes, nose and muzzle while obscuring the face." to "A mask of steel with a shape of a hound's muzzle which protects the eyes, nose and mouth while also obscuring the face it."

- "Gold Mask" name change to "gold mask" to match every other known item.
---

## Testing Evidence
All the testing proof needed is in the code itself mixed with the lack of conflicts as of time of writing.

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Mask side of things: The eyepatch gets a purpose, all the either masks that lacked a description or lacked a very informative one got a more informative one.
This should help give every item a purpose besides being a re-skin or barely being any different for what it is.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
