### PR TITLE
Armorer's Touch: helmets edition

### DIFF
--- a/code/modules/clothing/rogueclothes/hats.dm
+++ b/code/modules/clothing/rogueclothes/hats.dm
@@ -705,6 +705,7 @@
 	name = "horned cap"
 	desc = "An iron helmet with two horns poking out of the sides."
 	icon_state = "hornedcap"
+	max_integrity = 225
 	body_parts_covered = HEAD|HAIR
 	smeltresult = /obj/item/ingot/iron
 
@@ -712,6 +713,7 @@
 	name = "winged cap"
 	desc = "A helmet with two wings on its sides."
 	icon_state = "wingedcap"
+	max_integrity = 225
 	mob_overlay_icon = 'icons/roguetown/clothing/onmob/64x64/head.dmi'
 	worn_x_dimension = 64
 	worn_y_dimension = 64
@@ -721,6 +723,7 @@
 	name = "kettle helmet"
 	desc = "A steel helmet which protects the top and sides of the head."
 	icon_state = "kettle"
+	max_integrity = 215
 	body_parts_covered = HEAD|HAIR|EARS
 	armor = ARMOR_HEAD_HELMET
 
@@ -755,6 +758,7 @@
 	name = "sallet"
 	icon_state = "sallet"
 	desc = "A steel helmet which protects the ears."
+	max_integrity = 215
 	smeltresult = /obj/item/ingot/steel
 	body_parts_covered = HEAD|HAIR|EARS
 
@@ -782,8 +786,9 @@
 
 /obj/item/clothing/head/roguetown/helmet/sallet/visored
 	name = "visored sallet"
-	desc = "A steel helmet which protects the ears, nose, and eyes."
+	desc = "A steel helmet which protects the ears, and when the visor is flipped it includes the nose, and eyes at the cost of situational awareness."
 	icon_state = "sallet_visor"
+	max_integrity = 285
 	adjustable = CAN_CADJUST
 	flags_inv = HIDEFACE|HIDESNOUT|HIDEHAIR
 	flags_cover = HEADCOVERSEYES
@@ -862,7 +867,7 @@
 	prevent_crits = list(BCLASS_CUT, BCLASS_STAB, BCLASS_CHOP, BCLASS_BLUNT, BCLASS_SMASH, BCLASS_TWIST, BCLASS_PICK)
 	block2add = FOV_BEHIND
 	smeltresult = /obj/item/ingot/steel
-	max_integrity = 400
+	max_integrity = 350
 
 /obj/item/clothing/head/roguetown/helmet/heavy/aalloy
 	name = "decrepit barbute"
@@ -1033,7 +1038,7 @@
 	emote_environment = 3
 	flags_inv = HIDEEARS|HIDEFACE|HIDEHAIR|HIDESNOUT
 	block2add = FOV_BEHIND
-	max_integrity = 300
+	max_integrity = 325
 	smeltresult = /obj/item/ingot/steel
 	smelt_bar_num = 2
 
@@ -1128,6 +1133,7 @@
 	desc = "A helmet which covers the whole of the head. Offers excellent protection."
 	icon_state = "topfhelm"
 	item_state = "topfhelm"
+	max_integrity = 335
 	emote_environment = 3
 	flags_inv = HIDEEARS|HIDEFACE|HIDEHAIR|HIDESNOUT
 	block2add = FOV_BEHIND
@@ -1308,7 +1314,7 @@
 	body_parts_covered = HEAD|HAIR|EARS
 	flags_inv = HIDEEARS|HIDEHAIR
 	block2add = FOV_BEHIND
-	max_integrity = 300
+	max_integrity = 250
 	smeltresult = /obj/item/ingot/steel
 
 /obj/item/clothing/head/roguetown/helmet/bascinet/pigface
@@ -1316,6 +1322,7 @@
 	desc = "A steel bascinet helmet with a pigface visor that protects the entire head and face. Add a feather to show the colors of your family or allegiance."
 	icon_state = "hounskull"
 	item_state = "hounskull"
+	max_integrity = 325
 	adjustable = CAN_CADJUST
 	emote_environment = 3
 	body_parts_covered = FULL_HEAD
@@ -1473,17 +1480,6 @@
 			pic.color = get_detail_color()
 		add_overlay(pic)
 
-/obj/item/clothing/head/roguetown/helmet/bascinet
-	name = "bascinet"
-	desc = "A steel bascinet helmet. Though it lacks a visor for the face, it still protects the head and ears."
-	icon_state = "bascinet_novisor"
-	item_state = "bascinet_novisor"
-	emote_environment = 3
-	body_parts_covered = HEAD|HAIR|EARS
-	flags_inv = HIDEHAIR
-	block2add = null
-	smeltresult = /obj/item/ingot/steel
-
 /obj/item/clothing/head/roguetown/helmet/leather
 	slot_flags = ITEM_SLOT_HEAD|ITEM_SLOT_HIP
 	name = "leather helmet"
@@ -1506,7 +1502,7 @@
 	icon_state = "volfhead"
 	item_state = "volfhead"
 	armor = ARMOR_HEAD_HELMET_BAD
-	max_integrity = 100
+	max_integrity = 200
 	prevent_crits = list(BCLASS_BLUNT, BCLASS_TWIST)
 	anvilrepair = null
 	sewrepair = TRUE
@@ -1728,7 +1724,7 @@
 /obj/item/clothing/head/roguetown/helmet/tricorn
 	slot_flags = ITEM_SLOT_HEAD
 	name = "tricorn"
-	desc = ""
+	desc = "A hat worn by sailers, fencers, muskeeters and gentleman alike."
 	body_parts_covered = HEAD|HAIR|EARS|NOSE
 	icon_state = "tricorn"
 	armor = ARMOR_HEAD_CLOTHING
@@ -1751,7 +1747,7 @@
 /obj/item/clothing/head/roguetown/helmet/bandana
 	slot_flags = ITEM_SLOT_HEAD
 	name = "bandana"
-	desc = ""
+	desc = "Worn by sword fighters, thugs and pirates."
 	body_parts_covered = HEAD|HAIR|EARS|NOSE
 	icon_state = "bandana"
 	armor = ARMOR_HEAD_CLOTHING
@@ -1840,6 +1836,7 @@
 	desc = "A steel bascinet helmet with a volfish visor protecting the head, ears, eyes, nose and mouth."
 	icon_state = "volfplate"
 	item_state = "volfplate"
+	max_integrity = 325
 	adjustable = CAN_CADJUST
 	emote_environment = 3
 	flags_inv = HIDEEARS|HIDEFACE|HIDEHAIR|HIDESNOUT

--- a/code/modules/clothing/rogueclothes/hats.dm
+++ b/code/modules/clothing/rogueclothes/hats.dm
@@ -1724,7 +1724,7 @@
 /obj/item/clothing/head/roguetown/helmet/tricorn
 	slot_flags = ITEM_SLOT_HEAD
 	name = "tricorn"
-	desc = "A hat worn by sailers, fencers, muskeeters and gentleman alike."
+	desc = "A hat worn by sailors, fencers, musketeers and gentleman alike."
 	body_parts_covered = HEAD|HAIR|EARS|NOSE
 	icon_state = "tricorn"
 	armor = ARMOR_HEAD_CLOTHING


### PR DESCRIPTION
## About The Pull Request
- Decided to release them in their own smaller sections as to be easier to digest and read, he armorer's touch is a series of PRs that aims to add purpose to armor items, be they iron, steel or leather.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->
---
- # Things done
- Cloth/leather related.

- Volf helmet, integrity 100 > 200, it's leather.

- Tricorn
Added description "A hat worn by sailors, fencers, musketeers and gentleman alike."

- Bandana
Added description "Worn by sword fighters, thugs and pirates."
---
- Helmet related.

- Horned Cap, integrity 200 > 225.
- Winged Cap, integrity 200 > 225.
Reason, they cost the same as most of the other helmets, while covering less body parts, they require some sort of upside besides looking good.

- Kettle helmet, integrity 200 > 215, it's made out of steel.

- Sallet, integrity 200 > 215, it's made out of steel.
- Visored sallet, integrity 200 > 285, due to its cost to smith mixed with not losing too much vision while not protecting as much as the rest of the set, added with the fact of not losing parry angles with it, its durability has been increased.
- Description replaced from "A steel helmet which protects the ears, nose, and eyes." to "A steel helmet which protects the ears, and when the visor is flipped it includes the nose, and eyes at the cost of situational awareness."

- Barbute, integrity 400 < 350, due to its cost and lack of downsides that would block vision which limits parrying and situational awareness the helmet had its integrity lowered.
- Savoyard, integrity 400 < 350, same reason as above.
- Barred helmet, integrity 400 < 350, same reason as above.

- Knight's helmet, 300 > 325, due to losing the ability to parry from any angle that isn't the front, mixed with losing a lot of situational awareness the helmet has had a durability increase.
- Pigmask, 300 > 325 same as the above.
- Hounskull bascinet, 300 > 325 same as the above.
- Volf-face helm, 300 > 325, same as the above.

- Bucket helmets, 300 > 335, due to lack of a visor the helmet came sturdier than the rest. (It's less durable than the barcute because unlike it, it protects everything except the neck)

- Bascinet, 300 < 250, due to its low cost, barely any downside (if at all when a facemask is put on), its durability has decreased.
- Deletes a older version duplicate of the bascient that just didn't have any downsides while also using the same assets probably forming a few conflicts.

## Testing Evidence

The only proof needed is the code that has to be read regardless.

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
It's good for the game because it ensures not all armor items are the same, accounting for the cost to make them and their advantages and disadvantages.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
---
- Armorer's touch series' set: 
Set 1: https://github.com/BlackmoorHold/Blackmoor-hold/pull/69
Set 2: https://github.com/BlackmoorHold/Blackmoor-hold/pull/71 (This page)
Set 3: https://github.com/BlackmoorHold/Blackmoor-hold/pull/74
---