### PR TITLE
Armorer's Touch: Wrists and Neck edition

### DIFF
--- a/code/modules/cargo/packsrogue/merchant/armor.dm
+++ b/code/modules/cargo/packsrogue/merchant/armor.dm
@@ -26,12 +26,19 @@
 					/obj/item/clothing/head/roguetown/helmet/heavy/knight,
 				)
 
-/datum/supply_pack/rogue/armor/coif
-	name = "Cloth Coif"
-	cost = 10
+/datum/supply_pack/rogue/armor/coif/leather
+	name = "Leather Coif"
+	cost = 15
 	contains = list(
 					/obj/item/clothing/neck/roguetown/coif,
 				)
+
+/datum/supply_pack/rogue/armor/coif/cloth
+	name = "Cloth Coif"
+	cost = 10
+	contains = list(
+					/obj/item/clothing/neck/roguetown/coif/clothcoif,
+				)	
 
 /datum/supply_pack/rogue/armor/coif/steel
 	name = "Steel Coif"
@@ -56,7 +63,7 @@
 
 /datum/supply_pack/rogue/armor/leather
 	name = "Leather Armor"
-	cost = 10
+	cost = 20
 	contains = list(
 					/obj/item/clothing/suit/roguetown/armor/leather,
 				)
@@ -161,4 +168,3 @@
 	contains = list(
 					/obj/item/clothing/shoes/roguetown/boots/armor,
 				)
-

--- a/code/modules/clothing/rogueclothes/neck.dm
+++ b/code/modules/clothing/rogueclothes/neck.dm
@@ -22,10 +22,32 @@
 	user.update_inv_shirt()
 
 /obj/item/clothing/neck/roguetown/coif
-	name = "coif"
-	desc = "Cheap and easy to make. It's better than leaving your neck exposed."
+	name = "leather coif"
+	desc = "Leather coif, a comfortable wrapping around the neck and head, being more protective than its padded counter-part."
 	icon_state = "coif"
 	item_state = "coif"
+	max_integrity = 125
+	flags_inv = HIDEHAIR
+	slot_flags = ITEM_SLOT_NECK|ITEM_SLOT_HEAD
+	blocksound = SOFTHIT
+	body_parts_covered = NECK|HAIR|EARS|HEAD
+	armor = ARMOR_LEATHER
+	prevent_crits = list(BCLASS_CUT, BCLASS_STAB, BCLASS_BLUNT)
+	adjustable = CAN_CADJUST
+	toggle_icon_state = TRUE
+	sewrepair = TRUE
+	salvage_result = /obj/item/natural/hide/cured
+	salvage_amount = 1
+
+/obj/item/clothing/neck/roguetown/coif/ComponentInitialize()
+	AddComponent(/datum/component/adjustable_clothing, NECK, null, null, null, null, (UPD_HEAD|UPD_MASK|UPD_NECK))	//Soundless coif
+
+/obj/item/clothing/neck/roguetown/coif/clothcoif
+	name = "padded coif"
+	desc = "Cheap cloth padded coif, twice better at handling projectiles than its leather counter-part."
+	icon_state = "coif" // Lacks its own sprite/grey-sprite.
+	item_state = "coif" // Lacks its own sprite/grey-sprite.
+	max_integrity = 100
 	flags_inv = HIDEHAIR
 	slot_flags = ITEM_SLOT_NECK|ITEM_SLOT_HEAD
 	blocksound = SOFTHIT
@@ -35,33 +57,32 @@
 	adjustable = CAN_CADJUST
 	toggle_icon_state = TRUE
 	sewrepair = TRUE
-
-/obj/item/clothing/neck/roguetown/coif/ComponentInitialize()
-	AddComponent(/datum/component/adjustable_clothing, NECK, null, null, null, null, (UPD_HEAD|UPD_MASK|UPD_NECK))	//Soundless coif
+	salvage_result = /obj/item/natural/cloth
+	salvage_amount = 1
 
 /obj/item/clothing/neck/roguetown/leather
 	name = "hardened leather gorget"
 	desc = "Sturdy. Durable. Will protect your neck from some good lumbering."
 	icon_state = "lgorget"
+	max_integrity = 150
 	slot_flags = ITEM_SLOT_NECK
 	blocksound = SOFTHIT
 	body_parts_covered = NECK
 	body_parts_inherent = NECK
 	armor = ARMOR_LEATHER_GOOD
-	prevent_crits = list(BCLASS_CUT, BCLASS_CHOP, BCLASS_BLUNT, BCLASS_TWIST, BCLASS_SMASH)
+	prevent_crits = list(BCLASS_CUT, BCLASS_STAB, BCLASS_CHOP, BCLASS_BLUNT, BCLASS_TWIST, BCLASS_SMASH)
 	sewrepair = TRUE
-	max_integrity = 150
 	salvage_result = /obj/item/natural/hide/cured
 	salvage_amount = 1
 
 /obj/item/clothing/neck/roguetown/chaincoif
-	name = "chain coif"
+	name = "steel chain coif"
 	desc = "Offers superior coverage to a simple gorget, though it sacrifices some protection in return."
 	icon_state = "chaincoif"
 	item_state = "chaincoif"
+	max_integrity = 250
 	flags_inv = HIDEHAIR
 	armor = ARMOR_MAILLE
-	max_integrity = 200
 	resistance_flags = FIRE_PROOF
 	slot_flags = ITEM_SLOT_NECK|ITEM_SLOT_HEAD
 	body_parts_covered = NECK|HAIR|EARS|HEAD
@@ -79,46 +100,63 @@
 /obj/item/clothing/neck/roguetown/chaincoif/paalloy
 	name = "ancient coif"
 	desc = "a coif made of ancient alloys. Aeon's grasp lifted from its form."
+	max_integrity = 150
 	icon_state = "achaincoif"
 	smeltresult = /obj/item/ingot/aaslag
 
 /obj/item/clothing/neck/roguetown/chaincoif/chainmantle
-	name = "chain mantle"
+	name = "steel chain mantle"
 	desc = "A thicker and more durable piece of neck protection that also covers the mouth when pulled up."
 	icon_state = "chainmantle"
-	max_integrity = 300
+	max_integrity = 350
 	armor = ARMOR_MAILLE
 	body_parts_covered = NECK|MOUTH
 	slot_flags = ITEM_SLOT_NECK
 	flags_inv = HIDEFACE|HIDEFACIALHAIR|HIDESNOUT
+	smeltresult = /obj/item/ingot/steel
+	smelt_bar_num = 2
 
 /obj/item/clothing/neck/roguetown/chaincoif/chainmantle/ComponentInitialize()
 	AddComponent(/datum/component/adjustable_clothing, (NECK|MOUTH), null, null, 'sound/foley/equip/equip_armor_chain.ogg', null, (UPD_HEAD|UPD_MASK|UPD_NECK))	//Chain coif.
+
+/obj/item/clothing/neck/roguetown/chaincoif/chainmantle/iron
+	name = "iron chain mantle"
+	desc = "A thicker and more durable piece of neck protection that also covers the mouth when pulled up."
+	icon_state = "chainmantle"
+	max_integrity = 275
+	armor = ARMOR_MAILLE
+	body_parts_covered = NECK|MOUTH
+	slot_flags = ITEM_SLOT_NECK
+	flags_inv = HIDEFACE|HIDEFACIALHAIR|HIDESNOUT
+	smeltresult = /obj/item/ingot/iron
+	smelt_bar_num = 2
 
 /obj/item/clothing/neck/roguetown/chaincoif/iron
 	name = "iron chain coif"
 	desc = "A coif of meticulously crafted iron rings. It isn't steel, but metal is metal, and it might just save your life."
 	icon_state = "ichaincoif"
+	max_integrity = 150
 	anvilrepair = /datum/skill/craft/armorsmithing
 	smeltresult = /obj/item/ingot/iron
-	max_integrity = 150
-
 
 /obj/item/clothing/neck/roguetown/chaincoif/iron/aalloy
 	name = "decrepit coif"
 	desc = "a decrepit old coif. Aeon's grasp is upon it."
 	icon_state = "achaincoif"
-	smeltresult = /obj/item/ingot/aalloy
 	max_integrity = 100
+	smeltresult = /obj/item/ingot/aalloy
 
 
 /obj/item/clothing/neck/roguetown/chaincoif/full
-	name = "full chain coif"
+	name = "steel full chain coif"
 	icon_state = "fchaincoif"
+	max_integrity = 350
 	flags_inv = HIDEEARS|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
 	resistance_flags = FIRE_PROOF
-	body_parts_covered = NECK|MOUTH|NOSE|HAIR|EARS|HEAD
+	body_parts_covered = NECK|MOUTH|NOSE|HAIR|EARS|HEAD|CHEST|
 	adjustable = CAN_CADJUST
+	smeltresult = /obj/item/ingot/steel
+	smelt_bar_num = 2
 
 /obj/item/clothing/neck/roguetown/chaincoif/full/ComponentInitialize()
 	return
@@ -152,16 +190,25 @@
 			H.update_inv_neck()
 			H.update_inv_head()
 
+/obj/item/clothing/neck/roguetown/chaincoif/full/iron
+	name = "iron full chain coif"
+	icon_state = "fchaincoif" // Lacks its own sprite
+	max_integrity = 275
+	flags_inv = HIDEEARS|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
+	resistance_flags = FIRE_PROOF
+	body_parts_covered = NECK|MOUTH|NOSE|HAIR|EARS|HEAD|CHEST|
+	adjustable = CAN_CADJUST
+	smeltresult = /obj/item/ingot/iron
+	smelt_bar_num = 2
 
 /obj/item/clothing/neck/roguetown/bevor
 	name = "bevor"
 	desc = "A series of steel plates designed to protect the neck."
 	icon_state = "bevor"
+	max_integrity = 300
 	armor = ARMOR_BEVOR
 	anvilrepair = /datum/skill/craft/armorsmithing
 	smeltresult = /obj/item/ingot/steel
-
-	max_integrity = 300
 	resistance_flags = FIRE_PROOF
 	slot_flags = ITEM_SLOT_NECK
 	body_parts_covered = NECK|MOUTH|NOSE
@@ -169,7 +216,7 @@
 	blocksound = PLATEHIT
 
 /obj/item/clothing/neck/roguetown/gorget
-	name = "gorget"
+	name = "iron gorget"
 	desc = "A series of iron plates designed to protect the neck."
 	icon_state = "gorget"
 	armor = ARMOR_GORGET
@@ -193,6 +240,7 @@
 /obj/item/clothing/neck/roguetown/gorget/copper
 	name = "neck protector"
 	icon_state = "copperneck"
+	max_integrity = 125
 	desc = "An antique and simple protection for the neck, used more as an accessory by the common folk. But poor protection is still better than nothing."
 	armor = ARMOR_NECK_BAD
 	smeltresult = /obj/item/ingot/copper

--- a/code/modules/clothing/rogueclothes/wrists.dm
+++ b/code/modules/clothing/rogueclothes/wrists.dm
@@ -12,19 +12,28 @@
 	grid_height = 64
 
 /obj/item/clothing/wrists/roguetown/bracers
-	name = "bracers"
+	name = "steel bracers"
 	desc = "Steel bracers that protect the arms."
-	body_parts_covered = ARMS
 	icon_state = "bracers"
 	item_state = "bracers"
+	max_integrity = 300
 	armor = ARMOR_BOOTS_PLATED
 	prevent_crits = list(BCLASS_CUT, BCLASS_STAB, BCLASS_CHOP, BCLASS_BLUNT, BCLASS_TWIST)
 	blocksound = PLATEHIT
 	resistance_flags = FIRE_PROOF
-	max_integrity = 300
+
 	anvilrepair = /datum/skill/craft/armorsmithing
 	sewrepair = FALSE
 	smeltresult = /obj/item/ingot/steel
+
+/obj/item/clothing/wrists/roguetown/bracers/iron
+	name = "iron bracers"
+	desc = "Iron bracers that protect the arms."
+	icon_state = "bracers" // Lacks their own iron bracers sprite
+	item_state = "bracers" // Lacks their own iron bracers sprite
+	max_integrity = 260
+	armor = ARMOR_BOOTS_PLATED_IRON
+	smeltresult = /obj/item/ingot/iron
 
 /obj/item/clothing/wrists/roguetown/bracers/aalloy
 	name = "decrepit bracers"
@@ -44,7 +53,8 @@
 	desc = "Standard leather bracers that offer some meager protection for the arms."
 	icon_state = "lbracers"
 	item_state = "lbracers"
-	armor = ARMOR_PADDED_GOOD
+	max_integrity = 250
+	armor = ARMOR_LEATHER
 	prevent_crits = list(BCLASS_CUT, BCLASS_STAB, BCLASS_BLUNT, BCLASS_TWIST)
 	blocksound = SOFTHIT
 	blade_dulling = DULLING_BASHCHOP
@@ -61,7 +71,7 @@
 	icon_state = "albracers"
 	armor = ARMOR_LEATHER_GOOD
 	prevent_crits = list(BCLASS_CUT, BCLASS_BLUNT, BCLASS_TWIST, BCLASS_CHOP, BCLASS_SMASH)
-	max_integrity = 250
+	max_integrity = 265
 	salvage_amount = 1
 	salvage_result = /obj/item/natural/hide/cured
 
@@ -70,6 +80,7 @@
 	desc = "Copper forearm guards that offer some protection while looking rather stylish"
 	icon_state = "copperarm"
 	item_state = "copperarm"
+	max_integrity = 225
 	smeltresult = /obj/item/ingot/copper
 	armor = ARMOR_MASK_METAL_BAD
 
@@ -130,7 +141,7 @@
 	armor = ARMOR_LEATHER_STUDDED
 	prevent_crits = list(BCLASS_CUT, BCLASS_STAB, BCLASS_CHOP, BCLASS_BLUNT)
 	blocksound = SOFTHIT
-	max_integrity = 250
+	max_integrity = 285
 	anvilrepair = /datum/skill/craft/blacksmithing
 	smeltresult = /obj/item/ingot/iron
 	w_class = WEIGHT_CLASS_NORMAL

--- a/code/modules/roguetown/roguecrafting/leather/leather_armor_recipes.dm
+++ b/code/modules/roguetown/roguecrafting/leather/leather_armor_recipes.dm
@@ -87,7 +87,7 @@
 	sellprice = 26
 
 /datum/crafting_recipe/roguetown/leather/armor/cuirass
-	name = "leather cuirass"
+	name = "leather cuirass (2 leather)"
 	result = /obj/item/clothing/suit/roguetown/armor/leather/cuirass
 	reqs = list(/obj/item/natural/hide/cured = 2)
 	sellprice = 26
@@ -138,3 +138,9 @@
 	result = /obj/item/clothing/head/roguetown/helmet/leather
 	reqs = list(/obj/item/natural/hide/cured = 1)
 	sellprice = 27
+
+/datum/crafting_recipe/roguetown/leather/armor/lcoif
+	name = "leather coif (1 fibers, 1 leather)"
+	result = /obj/item/clothing/neck/roguetown/coif
+	reqs = list(/obj/item/natural/hide/cured = 1, /obj/item/natural/fibers = 1)
+	craftdiff = 1

--- a/code/modules/roguetown/roguecrafting/sewing.dm
+++ b/code/modules/roguetown/roguecrafting/sewing.dm
@@ -262,7 +262,7 @@
 
 /datum/crafting_recipe/roguetown/sewing/coif
 	name = "coif (1 fibers, 2 cloth)"
-	result = list(/obj/item/clothing/neck/roguetown/coif)
+	result = list(/obj/item/clothing/neck/roguetown/coif/clothcoif)
 	reqs = list(/obj/item/natural/cloth = 2,
 				/obj/item/natural/fibers = 1)
 	craftdiff = 3
@@ -394,27 +394,28 @@
 				/obj/item/natural/fibers = 1)
 	craftdiff = 4
 
-//datum/crafting_recipe/roguetown/sewing/Bladress
-//	name = "black dress"
-//	result = list(/obj/item/clothing/suit/roguetown/shirt/dress/gen/black)
-//	reqs = list(/obj/item/natural/cloth = 3,
-//				/obj/item/natural/fibers = 1)
-//	craftdiff = 4
+/* // Best guess why this was marked out, is due to the dye bin being a thing.
+datum/crafting_recipe/roguetown/sewing/Bladress
+	name = "black dress"
+	result = list(/obj/item/clothing/suit/roguetown/shirt/dress/gen/black)
+	reqs = list(/obj/item/natural/cloth = 3,
+				/obj/item/natural/fibers = 1)
+	craftdiff = 4
 
-//datum/crafting_recipe/roguetown/sewing/Bludress
-//	name = "blue dress"
-//	result = list(/obj/item/clothing/suit/roguetown/shirt/dress/gen/blue)
-//	reqs = list(/obj/item/natural/cloth = 3,
-//				/obj/item/natural/fibers = 1)
-//	craftdiff = 4
+datum/crafting_recipe/roguetown/sewing/Bludress
+	name = "blue dress"
+	result = list(/obj/item/clothing/suit/roguetown/shirt/dress/gen/blue)
+	reqs = list(/obj/item/natural/cloth = 3,
+				/obj/item/natural/fibers = 1)
+	craftdiff = 4
 
-//datum/crafting_recipe/roguetown/sewing/Purdress
-//	name = "purple dress"
-//	result = list(/obj/item/clothing/suit/roguetown/shirt/dress/gen/purple)
-//	reqs = list(/obj/item/natural/cloth = 3,
-//				/obj/item/natural/fibers = 1)
-//	craftdiff = 4
-
+datum/crafting_recipe/roguetown/sewing/Purdress
+	name = "purple dress"
+	result = list(/obj/item/clothing/suit/roguetown/shirt/dress/gen/purple)
+	reqs = list(/obj/item/natural/cloth = 3,
+				/obj/item/natural/fibers = 1)
+	craftdiff = 4
+*/
 /datum/crafting_recipe/roguetown/sewing/fancyhat
 	name = "fancy hat (1 fibers, 2 cloth)"
 	result = list(/obj/item/clothing/head/roguetown/fancyhat)

--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/armor.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/armor.dm
@@ -4,9 +4,9 @@
 	i_type = "Armor"
 	craftdiff = 1
 
-//For the sake of keeping the code modular with the introduction of new metals, each recipe has had it's main resource added to it's datum
-//This way, we can avoid having to name things in strange ways and can simply have iron/cuirass, stee/cuirass, blacksteel/cuirass->
-//-> and not messy names like ibreastplate and hplate
+// For the sake of keeping the code modular with the introduction of new metals, each recipe has had it's main resource added to it's datum
+// This way, we can avoid having to name things in strange ways and can simply have iron/cuirass, steel/cuirass, blacksteel/cuirass->
+// Instead of messy names like ibreastplate and hplate
 
 // --------- COPPER RECIPES -----------
 /datum/anvil_recipe/armor/copper/
@@ -444,6 +444,15 @@
 /datum/anvil_recipe/armor/steel/chainmantle
 	name = "Chain Mantle"
 	req_bar = /obj/item/ingot/steel
+	additional_items = list(/obj/item/ingot/steel)
+	created_item = /obj/item/clothing/neck/roguetown/chaincoif/chainmantle
+	createditem_num = 1
+	craftdiff = 2
+
+/datum/anvil_recipe/armor/steel/chainmantle/iron
+	name = "Chain Mantle"
+	req_bar = /obj/item/ingot/iron
+	additional_items = list(/obj/item/ingot/iron)
 	created_item = /obj/item/clothing/neck/roguetown/chaincoif/chainmantle
 	createditem_num = 1
 	craftdiff = 2
@@ -451,7 +460,15 @@
 /datum/anvil_recipe/armor/steel/fullchaincoif
 	name = "Full Chain Coif"
 	req_bar = /obj/item/ingot/steel
+	additional_items = list(/obj/item/ingot/steel)
 	created_item = /obj/item/clothing/neck/roguetown/chaincoif/full
+	craftdiff = 2
+
+/datum/anvil_recipe/armor/steel/fullchaincoif/iron
+	name = "Full Chain Coif"
+	req_bar = /obj/item/ingot/iron
+	additional_items = list(/obj/item/ingot/iron)
+	created_item = /obj/item/clothing/neck/roguetown/chaincoif/full/iron
 	craftdiff = 2
 
 /datum/anvil_recipe/armor/steel/chainglove
@@ -536,6 +553,12 @@
 	name = "Plate Bracers"
 	req_bar = /obj/item/ingot/steel
 	created_item = /obj/item/clothing/wrists/roguetown/bracers
+	createditem_num = 1
+
+/datum/anvil_recipe/armor/steel/platebracer/iron
+	name = "Plate Bracers"
+	req_bar = /obj/item/ingot/iron
+	created_item = /obj/item/clothing/wrists/roguetown/bracers/iron
 	createditem_num = 1
 
 /datum/anvil_recipe/armor/steel/helmetnasal


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->
---
## Wrist related
- Leather braces, integrity 250 < 300, and changed from armor padded good to armor leather type, these actions have been taken due to a clear over sight on the designation of this item.
- Hardened leather bracers, integrity 250 > 275, slight improvement in protection using the logic of being far easier to dictate how a hand gets hit over a leg.
- Copper braces, integrity 300 < 225, due to being copper.
- brigandine rerebraces, integrity 250 > 285, due to being made out of part iron.
- Renamed bracers to steel bracers and added a iron variant.
/obj/item/clothing/wrists/roguetown/bracers/iron with integrity 260, armor = ARMOR_BOOTS_PLATED_IRON
---

## Neck related
- Made the coif have two versions
/obj/item/clothing/neck/roguetown/coif/ (Leather version)
Added as a purchasable to the merchant for the price of 15
Leather coif giving it ARMOR_LEATHER
max_integrity = 125 (It's leather)
And
/obj/item/clothing/neck/roguetown/coif/clothcoif (Clothed padded version)
Modified as a purchasable to the merchant still being the price of 10
Padded coif ARMOR_PADDED_BAD
Integrity 100 (It's cloth)

- Neck protector, integrity 150 < 125, due to it being copper and because someone forget to set it a actual value.
Leather coif and Harden coif now prevent stab crits.

- Leather/cloth-padded coif now scavenge able, giving a respective 1 leather or cloth depending on the version.

- Coif descriptions
Old description "Cheap and easy to make. It's better than leaving your neck exposed."

Added leather coif description "Leather coif, a comfortable wrapping around the neck and head, being more protective than its padded counter-part."
Added cloth padded coif description "Cheap cloth padded coif, twice better at handling projectiles than its leather counter-part."

All alternative versions of coifs have been given a forge able and smeltable feature.

Coif, integrity 150, named it iron coif.
Steel coif, integrity 250, named it steel coif.
Full mantle, integrity 350, costs two steel to smith.
Full coif integrity 350, costs two steel to smith, it now also protects the chest.
Added an iron version of the full/mantle coif, they each have an integrity of 275. (Because iron)

## Misc
Leather armor upped in price from 10 to 20.

## Testing Evidence

Logic dictates that this should work.

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
Variety is the spice of life, this PR serves it on a platter, giving a use to each coif type, rebalancing integrity for things and armor types for others, as well as making things that should be scavenge able and smeltable possible in proper portions.
---
- Armorer's touch series' set: 
Set 1: https://github.com/BlackmoorHold/Blackmoor-hold/pull/69
Set 2: https://github.com/BlackmoorHold/Blackmoor-hold/pull/71
Set 3: https://github.com/BlackmoorHold/Blackmoor-hold/pull/74 (This page)
---