### PR TITLE
fixes latejoin marriage not respecting family option

### DIFF
--- a/code/__DEFINES/roguetown.dm
+++ b/code/__DEFINES/roguetown.dm
@@ -302,9 +302,9 @@ GLOBAL_LIST_EMPTY(confessors)
 GLOBAL_LIST_EMPTY(cuckolds)
 
 //preference stuff
-#define FAMILY_NONE 1
+#define FAMILY_NONE 0
 #define FAMILY_PARTIAL 2
-#define FAMILY_FULL 3
+#define FAMILY_FULL 1
 
 GLOBAL_LIST_EMPTY(sunlights)
 GLOBAL_LIST_EMPTY(head_bounties)


### PR DESCRIPTION
bit an oversight. though if there are any further issues all people would have to do is toggle family and save again.