### PR TITLE
Skirt and tasset leg coverage.

### DIFF
--- a/code/modules/clothing/rogueclothes/pants.dm
+++ b/code/modules/clothing/rogueclothes/pants.dm
@@ -422,12 +422,12 @@
 	AddComponent(/datum/component/item_equipped_movement_rustle, SFX_PLATE_STEP)
 
 /obj/item/clothing/under/roguetown/chainlegs/skirt
-	name = "steel chain skirt"
-	desc = "A knee-length maille skirt, warding cuts against the thighs without slowing the feet."
+	name = "steel mail skirt"
+	desc = "A knee-length mail skirt, warding cuts against the thighs without slowing the feet."
 	icon_state = "chain_skirt"
 	item_state = "chain_skirt"
-	body_parts_covered = GROIN
-	armor_class = ARMOR_CLASS_LIGHT
+	body_parts_covered = LEGS
+	armor_class = ARMOR_CLASS_LIGHT	// Coverage to class trade.
 
 /obj/item/clothing/under/roguetown/platelegs/skirt
 	name = "steel plate tassets"
@@ -435,8 +435,8 @@
 	gender = PLURAL
 	icon_state = "plate_skirt"
 	item_state = "plate_skirt"
-	body_parts_covered = GROIN
-	armor_class = ARMOR_CLASS_LIGHT
+	body_parts_covered = LEGS
+	armor_class = ARMOR_CLASS_MEDIUM // Coverage to class trade.
 
 /obj/item/clothing/under/roguetown/loincloth
 	name = "loincloth"


### PR DESCRIPTION
Following a concept of 'reduced coverage for higher protection', shifted skirts to be chainmail leg armor with the groin as a weak spot. Allows light and medium armor users to 'step up' their leg armor without losing dodge or requiring heavy armor training, but simultaneously creates a new risk of groin strikes. This in turn shifts attacks to the chest, creating a shift in the combat meta away from limb strikes.

Discussed with Neo directly.

![image](https://github.com/user-attachments/assets/c1057f9d-547b-48ba-a6a6-4ebffe134a5b)
