### PR TITLE
Adds Belly Markings to Half-Kin

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/furry/demihuman.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/demihuman.dm
@@ -68,6 +68,7 @@
 		)
 	body_marking_sets = list(
 		/datum/body_marking_set/none,
+		/datum/body_marking_set/belly,
 		/datum/body_marking_set/socks,
 		/datum/body_marking_set/tiger,
 		/datum/body_marking_set/tiger_dark,


### PR DESCRIPTION
## About The Pull Request

Belly markings were present on just about every race except half-kin for some strange reason. These markings are useful because they can be used to hide muscle definition or alternatively be layered over with the tonage markings for a different look. All that was added was a single line of code to make them available to half-kin.

## Testing Evidence

![belly1](https://github.com/user-attachments/assets/2fe143f2-db5c-4ca2-b40c-ed981db89e76)
![belly2](https://github.com/user-attachments/assets/d39af70e-3f08-452a-8dbf-ebe4c074db9d)

## Why It's Good For The Game

More twinks for everyone.




