### PR TITLE
Purpose and balance: Whole weaponry edition. (Scavenge bits PR, do not merge, do not close, I am dissecting worthy things from it)

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/axes.dm
+++ b/code/game/objects/items/rogueweapons/melee/axes.dm
@@ -7,6 +7,7 @@
 	attack_verb = list("cuts", "slashes")
 	hitsound = list('sound/combat/hits/bladed/smallslash (1).ogg', 'sound/combat/hits/bladed/smallslash (2).ogg', 'sound/combat/hits/bladed/smallslash (3).ogg')
 	animname = "cut"
+	damfactor = 0.9 // Had the option to choose between delay attack (bad feel) or lower damage.
 	penfactor = 20
 	chargetime = 0
 	item_d_type = "slash"
@@ -18,7 +19,7 @@
 	attack_verb = list("chops", "hacks")
 	animname = "chop"
 	hitsound = list('sound/combat/hits/bladed/genchop (1).ogg', 'sound/combat/hits/bladed/genchop (2).ogg', 'sound/combat/hits/bladed/genchop (3).ogg')
-	penfactor = 35
+	penfactor = 30
 	swingdelay = 10
 	clickcd = 14
 	item_d_type = "slash"
@@ -27,14 +28,14 @@
 	reach = 2
 
 /datum/intent/axe/chop/stone
-	penfactor = 5
+	penfactor = 10
 
 /datum/intent/axe/chop/battle
-	damfactor = 1.2 //36 on battleaxe
-	penfactor = 40
+	damfactor = 1.15 // 34.5 on battleaxe, 36.8 on Oath axe
+	penfactor = 45
 
 /datum/intent/axe/cut/battle
-	penfactor = 25
+	penfactor = 30
 
 /datum/intent/axe/bash
 	name = "bash"
@@ -44,7 +45,7 @@
 	blade_class = BCLASS_BLUNT
 	hitsound = list('sound/combat/hits/blunt/metalblunt (1).ogg', 'sound/combat/hits/blunt/metalblunt (2).ogg', 'sound/combat/hits/blunt/metalblunt (3).ogg')
 	chargetime = 0
-	penfactor = BLUNT_DEFAULT_PENFACTOR
+	penfactor = 20
 	swingdelay = 5
 	damfactor = 1.1
 	item_d_type = "blunt"
@@ -138,10 +139,10 @@
 
 // Battle Axe
 /obj/item/rogueweapon/stoneaxe/battle
-	force = 25
+	force = 15
 	force_wielded = 30
 	possible_item_intents = list(/datum/intent/axe/cut/battle, /datum/intent/axe/chop/battle, /datum/intent/axe/bash, /datum/intent/sword/peel)
-	wlength = WLENGTH_LONG		//It's a big battle-axe.
+	wlength = WLENGTH_NORMAL
 	name = "battle axe"
 	desc = "A steel battleaxe of war. Has a wicked edge."
 	icon_state = "battleaxe"
@@ -165,8 +166,8 @@
 
 
 /obj/item/rogueweapon/stoneaxe/oath
-	force = 30
-	force_wielded = 40
+	force = 17
+	force_wielded = 32
 	possible_item_intents = list(/datum/intent/axe/cut/battle, /datum/intent/axe/chop/battle, /datum/intent/axe/bash)
 	name = "oath"
 	desc = "A hefty, steel-forged axe marred by the touch of countless Wardens. Despite it's weathered etchings and worn grip, the blade has been honed to a razor's edge and you can see your reflection in the finely polished metal."
@@ -174,7 +175,7 @@
 	icon = 'icons/roguetown/weapons/64.dmi'
 	max_blade_int = 500
 	dropshrink = 0.75
-	wlength = WLENGTH_LONG
+	wlength = WLENGTH_NORMAL
 	slot_flags = ITEM_SLOT_BACK
 	pixel_y = -16
 	pixel_x = -16
@@ -228,8 +229,10 @@
 	name = "Pulaski axe"
 	desc = "An odd mix of a pickaxe front and a hatchet blade back, capable of being switched between."
 	icon_state = "paxe"
-	possible_item_intents = list(/datum/intent/axe/cut,/datum/intent/axe/chop, /datum/intent/mace/warhammer/pick, /datum/intent/axe/bash)
-	gripped_intents = list(/datum/intent/axe/cut,/datum/intent/axe/chop, /datum/intent/mace/warhammer/pick, /datum/intent/axe/bash)
+	force = 19
+	force_wielded = 25
+	possible_item_intents = list(/datum/intent/axe/cut, /datum/intent/axe/chop, /datum/intent/mace/warhammer/pick, /datum/intent/axe/bash)
+	gripped_intents = list(/datum/intent/axe/cut, /datum/intent/axe/chop, /datum/intent/mace/warhammer/pick, /datum/intent/axe/bash)
 	smeltresult = /obj/item/ingot/steel
 	wlength = WLENGTH_NORMAL
 	toolspeed = 2
@@ -279,7 +282,7 @@
 	name = "steel axe"
 	icon_state = "saxe"
 	desc = "A steel woodcutting axe. Performs much better than its iron counterpart."
-	force = 26
+	force = 20
 	force_wielded = 28
 	max_blade_int = 500
 	smeltresult = /obj/item/ingot/steel
@@ -340,8 +343,8 @@
 	name = "silver war axe"
 	desc = "A one-handed war axe forged of silver."
 	icon_state = "silveraxe"
-	force = 24
-	possible_item_intents = list(/datum/intent/axe/cut,/datum/intent/axe/chop, /datum/intent/axe/bash)
+	force = 22
+	possible_item_intents = list(/datum/intent/axe/cut, /datum/intent/axe/chop, /datum/intent/axe/bash)
 	minstr = 6
 	max_blade_int = 400
 	smeltresult = /obj/item/ingot/silver
@@ -363,9 +366,13 @@
 
 
 /datum/intent/axe/cut/battle/greataxe
+	swingdelay = 6
+	damfactor = 0.95
 	reach = 2
 
 /datum/intent/axe/chop/battle/greataxe
+	swingdelay = 12
+	damfactor = 1.03
 	reach = 2
 
 /obj/item/rogueweapon/greataxe
@@ -411,8 +418,8 @@
 				return list("shrink" = 0.3,"sx" = -2,"sy" = -5,"nx" = 4,"ny" = -5,"wx" = 0,"wy" = -5,"ex" = 2,"ey" = -5,"nturn" = 0,"sturn" = 0,"wturn" = 0,"eturn" = 0,"nflip" = 0,"sflip" = 0,"wflip" = 0,"eflip" = 0,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)
 
 /obj/item/rogueweapon/greataxe/steel
-	force = 15
-	force_wielded = 30
+	force = 16
+	force_wielded = 31
 	possible_item_intents = list(/datum/intent/axe/cut, /datum/intent/axe/chop, SPEAR_BASH) //bash is for nonlethal takedowns, only targets limbs
 	gripped_intents = list(/datum/intent/axe/cut/battle/greataxe, /datum/intent/axe/chop/battle/greataxe, /datum/intent/sword/peel/big, SPEAR_BASH)
 	name = "steel greataxe"

--- a/code/game/objects/items/rogueweapons/melee/blunt.dm
+++ b/code/game/objects/items/rogueweapons/melee/blunt.dm
@@ -3,12 +3,11 @@
 /datum/intent/mace/strike
 	name = "strike"
 	blade_class = BCLASS_BLUNT
-	attack_verb = list("strikes", "hits")
+	attack_verb = list("strikes", "whacks")
 	hitsound = list('sound/combat/hits/blunt/metalblunt (1).ogg', 'sound/combat/hits/blunt/metalblunt (2).ogg', 'sound/combat/hits/blunt/metalblunt (3).ogg')
 	chargetime = 0
-	penfactor = BLUNT_DEFAULT_PENFACTOR
-	damfactor = 1.1
-	swingdelay = 0
+	penfactor = 20
+	swingdelay = 4 // Idea behind it, is to balance out swift intent and give this weapon a purpose more damage at the cost of delay.
 	icon_state = "instrike"
 	item_d_type = "blunt"
 
@@ -17,13 +16,47 @@
 	blade_class = BCLASS_SMASH
 	attack_verb = list("smashes")
 	hitsound = list('sound/combat/hits/blunt/metalblunt (1).ogg', 'sound/combat/hits/blunt/metalblunt (2).ogg', 'sound/combat/hits/blunt/metalblunt (3).ogg')
-	penfactor = BLUNT_DEFAULT_PENFACTOR
+	penfactor = 70
 	damfactor = 1.5
 	swingdelay = 10
 	clickcd = 14
 	icon_state = "insmash"
 	item_d_type = "blunt"
 
+/datum/intent/mace/tapstrike
+	name = "tap strike"
+	blade_class = BCLASS_BLUNT
+	attack_verb = list("taps", "tapped")
+	hitsound = list('sound/combat/hits/blunt/woodblunt (1).ogg', 'sound/combat/hits/blunt/woodblunt (2).ogg')
+	chargetime = 0
+	penfactor = 5
+	damfactor = 0.01
+	swingdelay = 0
+	icon_state = "instrike"
+	item_d_type = "blunt"
+
+/datum/intent/mace/tapstrike/club
+	swingdelay = 4 // Here to simulate the same strike from a mace.
+
+/datum/intent/mace/tapsmash
+	name = "tap smash"
+	blade_class = BCLASS_SMASH
+	attack_verb = list("taps", "tapped")
+	hitsound = list('sound/combat/hits/blunt/woodblunt (1).ogg', 'sound/combat/hits/blunt/woodblunt (2).ogg')
+	chargetime = 0
+	penfactor = 5
+	damfactor = 0.01
+	swingdelay = 10
+	clickcd = 14
+	icon_state = "insmash"
+	item_d_type = "blunt"
+
+/datum/intent/mace/tapsmash/sword
+	name = "tap chop"
+	animname = "chop"
+	swingdelay = 8
+	clickcd = 12
+	icon_state = "inchop"
 
 /datum/intent/mace/rangedthrust
 	name = "thrust"
@@ -32,7 +65,7 @@
 	animname = "stab"
 	icon_state = "instab"
 	reach = 2
-	chargetime = 1
+	chargetime = 1.5
 	recovery = 30
 	warnie = "mobwarning"
 	hitsound = list('sound/combat/hits/bladed/genstab (1).ogg', 'sound/combat/hits/bladed/genstab (2).ogg', 'sound/combat/hits/bladed/genstab (3).ogg')
@@ -101,7 +134,7 @@
 
 
 /obj/item/rogueweapon/mace/church
-	force = 25
+	force = 15
 	force_wielded = 30
 	name = "bell ringer"
 	desc = "This heavy hammer is used to ring the church's bell."
@@ -111,8 +144,8 @@
 	wdefense = 3
 
 /obj/item/rogueweapon/mace/steel
-	force = 25
-	force_wielded = 32
+	force = 22
+	force_wielded = 29
 	name = "steel mace"
 	desc = "This steel mace is objectively superior to an iron one."
 	icon_state = "smace"
@@ -156,13 +189,13 @@
 	force = 15
 	force_wielded = 18
 	name = "wooden club"
-	desc = "A primitive cudgel carved of a stout piece of treefall."
+	desc = "A primitive club carved of a stout piece of treefall."
 	icon_state = "club1"
 	//dropshrink = 0.75
 	wbalance = WBALANCE_NORMAL
-	wdefense = 1
-	possible_item_intents = list(/datum/intent/mace/strike/wood)
-	gripped_intents = list(/datum/intent/mace/strike/wood, /datum/intent/mace/smash/wood)
+	wdefense = 2
+	possible_item_intents = list(/datum/intent/mace/strike/wood, /datum/intent/mace/tapstrike/club)
+	gripped_intents = list(/datum/intent/mace/strike/wood, /datum/intent/mace/smash/wood, /datum/intent/mace/tapstrike/club, /datum/intent/mace/tapsmash)
 	smeltresult = /obj/item/ash
 	anvilrepair = /datum/skill/craft/carpentry
 	blade_dulling = DULLING_SHAFT_WOOD
@@ -175,11 +208,12 @@
 
 /datum/intent/mace/strike/wood
 	hitsound = list('sound/combat/hits/blunt/woodblunt (1).ogg', 'sound/combat/hits/blunt/woodblunt (2).ogg')
-	penfactor = BLUNT_DEFAULT_PENFACTOR
+	penfactor = 10
+	swingdelay = 0
 
 /datum/intent/mace/smash/wood
 	hitsound = list('sound/combat/hits/blunt/woodblunt (1).ogg', 'sound/combat/hits/blunt/woodblunt (2).ogg')
-	penfactor = BLUNT_DEFAULT_PENFACTOR
+	penfactor = 20
 
 /datum/intent/mace/smash/wood/ranged
 	reach = 2
@@ -188,20 +222,30 @@
 	name = "cudgel"
 	desc = "A stubby little club for brigands or thieves. Attempting parries with this is a bad idea."
 	force = 25
-	icon_state = "cudgel"
 	force_wielded = 25
-	possible_item_intents = list(/datum/intent/mace/strike)
-	gripped_intents = list(/datum/intent/mace/smash, /datum/intent/mace/strike)
-	smeltresult = /obj/item/ash
+	icon_state = "cudgel"
+	possible_item_intents = list(/datum/intent/mace/strike/cudgel)
+	gripped_intents = list(/datum/intent/mace/strike/cudgel, /datum/intent/mace/smash/cudgel)
+	smeltresult = /obj/item/iron
 	wlength = WLENGTH_SHORT
 	w_class = WEIGHT_CLASS_NORMAL
 	wbalance = WBALANCE_NORMAL
-	minstr = 7
-	wdefense = 1
+	minstr = 5
+	wdefense = 0.5
 	resistance_flags = FLAMMABLE
 	blade_dulling = DULLING_SHAFT_WOOD
 	grid_width = 32
 	grid_height = 96
+
+/datum/intent/mace/strike/cudgel
+	penfactor = 10
+	swingdelay = 0
+
+/datum/intent/mace/smash/cudgel
+	penfactor = 30
+	damfactor = 1.25
+	swingdelay = 6
+	clickcd = 12
 
 /obj/item/rogueweapon/mace/cudgel/copper
 	name = "copper bludgeon"
@@ -215,17 +259,17 @@
 /obj/item/rogueweapon/mace/cudgel/justice
 	name = "'Justice'"
 	desc = "The icon of the right of office of the Marshal. While mostly ceremonial in design, it serves it's purpose in dishing out some much needed justice."
-	force = 30
+	force = 27.5
 	icon_state = "justice"
-	force_wielded = 30
-	gripped_intents = list(/datum/intent/mace/strike,/datum/intent/mace/smash)
+	force_wielded = 27.5
+	gripped_intents = list(/datum/intent/mace/strike/cudgel, /datum/intent/mace/smash/cudgel)
 	smeltresult = /obj/item/ingot/steel
 	wlength = WLENGTH_SHORT
 	w_class = WEIGHT_CLASS_NORMAL
 	blade_dulling = DULLING_SHAFT_REINFORCED
 	wbalance = WBALANCE_SWIFT
 	minstr = 7
-	wdefense = 5
+	wdefense = 4.5
 
 /obj/item/rogueweapon/mace/cudgel/getonmobprop(tag)
 	. = ..()
@@ -238,13 +282,13 @@
 
 /obj/item/rogueweapon/mace/wsword
 	name = "wooden sword"
-	desc = "This wooden sword is great for training."
+	desc = "This wooden sword is great for training. Or humiliating opponents."
 	force = 5
 	force_wielded = 8
 	icon_state = "wsword"
 	//dropshrink = 0.75
-	possible_item_intents = list(/datum/intent/mace/strike/wood)
-	gripped_intents = list(/datum/intent/mace/strike/wood, /datum/intent/mace/smash/wood)
+	possible_item_intents = list(/datum/intent/mace/strike/wood, /datum/intent/mace/tapstrike)
+	gripped_intents = list(/datum/intent/mace/strike/wood, /datum/intent/mace/smash/wood, /datum/intent/mace/tapstrike, /datum/intent/mace/tapsmash/sword)
 	smeltresult = /obj/item/ash
 	minstr = 7
 	wdefense = 5
@@ -308,7 +352,7 @@
 
 
 /obj/item/rogueweapon/mace/goden
-	force = 15
+	force = 16.5
 	force_wielded = 30
 	possible_item_intents = list(/datum/intent/mace/strike)
 	gripped_intents = list(/datum/intent/mace/strike, /datum/intent/mace/smash, /datum/intent/mace/rangedthrust, /datum/intent/effect/daze)
@@ -358,8 +402,8 @@
 	name = "grand mace"
 	desc = "Good morning, sire."
 	icon_state = "polemace"
-	force = 15
-	force_wielded = 35
+	force = 16.5
+	force_wielded = 33
 	smeltresult = /obj/item/ingot/steel
 	blade_dulling = DULLING_SHAFT_METAL
 	smelt_bar_num = 2
@@ -394,8 +438,8 @@
 	name = "Silver mace"
 	desc = "An ornate mace, plated in a ceremonial veneer of silver. Even the unholy aren't immune to discombobulation."
 	icon_state = "psymace"
-	force = 25
-	force_wielded = 32
+	force = 22
+	force_wielded = 29
 	wbalance = WBALANCE_HEAVY
 	dropshrink = 0.75
 	slot_flags = ITEM_SLOT_BACK //Looks better on back
@@ -480,7 +524,7 @@
 	animname = "stab"
 	hitsound = list('sound/combat/hits/blunt/metalblunt (1).ogg', 'sound/combat/hits/blunt/metalblunt (2).ogg', 'sound/combat/hits/blunt/metalblunt (3).ogg')
 	misscost = 1
-	swingdelay = 15
+	swingdelay = 20
 	clickcd = 15
 	penfactor = 80
 	damfactor = 0.9

--- a/code/game/objects/items/rogueweapons/melee/blunt.dm
+++ b/code/game/objects/items/rogueweapons/melee/blunt.dm
@@ -226,7 +226,7 @@
 	icon_state = "cudgel"
 	possible_item_intents = list(/datum/intent/mace/strike/cudgel)
 	gripped_intents = list(/datum/intent/mace/strike/cudgel, /datum/intent/mace/smash/cudgel)
-	smeltresult = /obj/item/iron
+	smeltresult = /obj/item/ingot/iron
 	wlength = WLENGTH_SHORT
 	w_class = WEIGHT_CLASS_NORMAL
 	wbalance = WBALANCE_NORMAL

--- a/code/game/objects/items/rogueweapons/melee/flail.dm
+++ b/code/game/objects/items/rogueweapons/melee/flail.dm
@@ -1,37 +1,12 @@
-/obj/item/rogueweapon/flail
-	force = 25
-	possible_item_intents = list(/datum/intent/flail/strike, /datum/intent/flail/strike/smash)
-	name = "flail"
-	desc = "This is a swift, iron flail. Strikes hard and far."
-	icon_state = "iflail"
-	icon = 'icons/roguetown/weapons/32.dmi'
-	sharpness = IS_BLUNT
-	//dropshrink = 0.75
-	wlength = WLENGTH_NORMAL
-	w_class = WEIGHT_CLASS_NORMAL
-	slot_flags = ITEM_SLOT_HIP | ITEM_SLOT_BACK
-	associated_skill = /datum/skill/combat/whipsflails
-	anvilrepair = /datum/skill/craft/weaponsmithing
-	smeltresult = /obj/item/ingot/iron
-	parrysound = list('sound/combat/parry/parrygen.ogg')
-	swingsound = BLUNTWOOSH_MED
-	blade_dulling = DULLING_SHAFT_WOOD
-	throwforce = 5
-	wdefense = 0
-	minstr = 4
-	grid_width = 32
-	grid_height = 96
-	intdamage_factor = 1.1
-	pickup_sound = 'sound/foley/equip/equip_armor_chain.ogg'
-	sheathe_sound = 'sound/items/wood_sharpen.ogg'
+//intent datums ฅ^•ﻌ•^ฅ 
 
 /datum/intent/flail/strike
 	name = "strike"
 	blade_class = BCLASS_BLUNT
-	attack_verb = list("strikes", "hits")
+	attack_verb = list("strikes", "whacks")
 	hitsound = list('sound/combat/hits/blunt/flailhit.ogg')
 	chargetime = 0
-	penfactor = BLUNT_DEFAULT_PENFACTOR
+	penfactor = 10
 	icon_state = "instrike"
 	item_d_type = "blunt"
 
@@ -41,11 +16,12 @@
 /datum/intent/flail/strikerange
 	name = "ranged strike"
 	blade_class = BCLASS_BLUNT
-	attack_verb = list("strikes", "hits")
+	attack_verb = list("strikes", "whacks")
 	hitsound = list('sound/combat/hits/blunt/flailhit.ogg')
-	chargetime = 0
+	chargetime = 20
 	recovery = 15
-	penfactor = BLUNT_DEFAULT_PENFACTOR
+	penfactor = 20
+	swingdelay = 2.5
 	reach = 2
 	icon_state = "instrike"
 	item_d_type = "blunt"
@@ -55,7 +31,7 @@
 	chargetime = 5
 	chargedrain = 2
 	no_early_release = TRUE
-	penfactor = BLUNT_DEFAULT_PENFACTOR
+	penfactor = 70
 	recovery = 10
 	damfactor = 1.6
 	chargedloop = /datum/looping_sound/flailswing
@@ -81,9 +57,10 @@
 	chargedrain = 2
 	no_early_release = TRUE
 	recovery = 30
-	damfactor = 1.5
-	penfactor = BLUNT_DEFAULT_PENFACTOR
+	damfactor = 1.65
+	penfactor = 75
 	reach = 2
+	swingdelay = 5
 	chargedloop = /datum/looping_sound/flailswing
 	keep_looping = TRUE
 	icon_state = "insmash"
@@ -101,12 +78,53 @@
 			if("onbelt")
 				return list("shrink" = 0.3,"sx" = -2,"sy" = -5,"nx" = 4,"ny" = -5,"wx" = 0,"wy" = -5,"ex" = 2,"ey" = -5,"nturn" = 0,"sturn" = 0,"wturn" = 0,"eturn" = 0,"nflip" = 0,"sflip" = 0,"wflip" = 0,"eflip" = 0,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)
 
+/datum/intent/flail/suckercurverange // Currently not in use, maybe make it an alt grip.
+	name = "sucker curve"
+	blade_class = BCLASS_BLUNT
+	attack_verb = list("curve strikes", "curve whacks")
+	hitsound = list('sound/combat/hits/blunt/flailhit.ogg')
+	chargetime = 10
+	recovery = 10
+	damfactor = 0.85
+	penfactor = 20
+	swingdelay = 2.5
+	reach = 2
+	icon_state = "instrike"
+	item_d_type = "blunt"
+	canparry = FALSE
+
+/obj/item/rogueweapon/flail
+	force = 15
+	possible_item_intents = list(/datum/intent/flail/strike, /datum/intent/flail/strikerange, /datum/intent/flail/strike/smash, /datum/intent/flail/strike/smashrange)
+	name = "flail"
+	desc = "This is a swift, iron flail. Strikes hard and far."
+	icon_state = "iflail"
+	icon = 'icons/roguetown/weapons/32.dmi'
+	sharpness = IS_BLUNT
+	//dropshrink = 0.75
+	wlength = WLENGTH_NORMAL
+	w_class = WEIGHT_CLASS_NORMAL
+	slot_flags = ITEM_SLOT_HIP | ITEM_SLOT_BACK
+	associated_skill = /datum/skill/combat/whipsflails
+	anvilrepair = /datum/skill/craft/weaponsmithing
+	smeltresult = /obj/item/ingot/iron
+	parrysound = list('sound/combat/parry/parrygen.ogg')
+	swingsound = BLUNTWOOSH_MED
+	blade_dulling = DULLING_SHAFT_WOOD
+	throwforce = 5
+	wdefense = 0
+	minstr = 4
+	grid_width = 32
+	grid_height = 96
+	intdamage_factor = 1.1
+	pickup_sound = 'sound/foley/equip/equip_armor_chain.ogg'
+	sheathe_sound = 'sound/items/wood_sharpen.ogg'
 
 /obj/item/rogueweapon/flail/aflail
 	name = "decrepit flail"
 	desc = "This is a swift, ancient flail. Strikes hard and far. Aeon's grasp is upon its form."
 	icon_state = "aflail"
-	force = 22
+	force = 18
 	max_integrity = 175
 	smeltresult = /obj/item/ingot/aalloy
 	blade_dulling = DULLING_SHAFT_CONJURED
@@ -118,7 +136,7 @@
 	smeltresult = /obj/item/ingot/aaslag
 
 /obj/item/rogueweapon/flail/sflail
-	force = 30
+	force = 21
 	icon_state = "flail"
 	desc = "This is a swift, steel flail. Strikes hard and far."
 	smeltresult = /obj/item/ingot/steel
@@ -141,44 +159,61 @@
 /datum/intent/whip/lash
 	name = "lash"
 	blade_class = BCLASS_BLUNT
-	attack_verb = list("lashes", "cracks")
+	attack_verb = list("lashes", "whips")
 	hitsound = list('sound/combat/hits/blunt/flailhit.ogg')
 	chargetime = 0
 	recovery = 7
-	penfactor = BLUNT_DEFAULT_PENFACTOR
+	penfactor = 10
 	damfactor = 1.1
 	reach = 2
 	icon_state = "inlash"
-	item_d_type = "slash"
+	item_d_type = "blunt"
 
 /datum/intent/whip/crack
 	name = "crack"
-	blade_class = BCLASS_CUT
-	attack_verb = list("cracks", "strikes") //something something dwarf fotresss
+	blade_class = BCLASS_STAB
+	attack_verb = list("cracks", "snap-lashes") //something something dwarf fotresss
 	hitsound = list('sound/combat/hits/blunt/flailhit.ogg')
 	chargetime = 0
 	recovery = 10
 	penfactor = 40
 	reach = 3
+	swingdelay = 2.5
 	icon_state = "incrack"
-	item_d_type = "slash"
+	item_d_type = "stab"
 
-/datum/intent/whip/punish
+/datum/intent/whip/punish // This is purely for roleplay punishing.
 	name = "punish"
 	blade_class = BCLASS_BLUNT
-	attack_verb = list("lashes")
+	attack_verb = list("punish-lashes, punish-whips")
 	hitsound = list('sound/combat/hits/blunt/flailhit.ogg')
 	chargetime = 0
 	recovery = 10
-	penfactor = BLUNT_DEFAULT_PENFACTOR
+	damfactor = 0.2
+	penfactor = 20
 	reach = 2
 	icon_state = "inpunish"
 	item_d_type = "blunt"
 
+/datum/intent/whip/suckercurveranged // To get around dodge and parries, might give an accuracy penalty later
+	name = "sucker lash"
+	blade_class = BCLASS_BLUNT
+	attack_verb = list("punish-lashes, punish-whips")
+	hitsound = list('sound/combat/hits/blunt/flailhit.ogg')
+	chargetime = 0
+	recovery = 10
+	damfactor = 0.75
+	penfactor = 10
+	reach = 2
+	icon_state = "instrike"
+	item_d_type = "blunt"
+	canparry = FALSE
+	candodge = FALSE
+
 /obj/item/rogueweapon/whip
 	force = 21
-	possible_item_intents = list(/datum/intent/whip/crack, /datum/intent/whip/lash, /datum/intent/whip/punish)
-	name = "whip"
+	possible_item_intents = list(/datum/intent/whip/crack, /datum/intent/whip/lash, /datum/intent/whip/punish, /datum/intent/whip/suckercurveranged)
+	name = "leather whip"
 	desc = "A leather whip. Built to last, with a sharp stone for a tip."
 	icon_state = "whip"
 	icon = 'icons/roguetown/weapons/32.dmi'
@@ -186,7 +221,7 @@
 	//dropshrink = 0.75
 	wlength = WLENGTH_NORMAL
 	w_class = WEIGHT_CLASS_NORMAL
-	slot_flags = ITEM_SLOT_HIP | ITEM_SLOT_BELT
+	slot_flags = ITEM_SLOT_HIP
 	associated_skill = /datum/skill/combat/whipsflails
 	anvilrepair = /datum/skill/craft/tanning
 	parrysound = list('sound/combat/parry/parrygen.ogg')
@@ -222,18 +257,18 @@
 	name = "nagaika whip"
 	desc = "A short but heavy leather whip, sporting a blunt reinforced tip and a longer handle."
 	icon_state = "nagaika"
-	force = 25		//Same as a cudgel/sword for intent purposes. Basically a 2 range cudgel while one-handing.
+	force = 20		// Basically a 2 range cudgel while one-handing it with the crack-blunt intent.
 	possible_item_intents = list(/datum/intent/whip/crack/blunt, /datum/intent/whip/lash, /datum/intent/whip/punish, /datum/intent/sword/strike)
-	wdefense = 1	//Akin to a cudgel, still terrible at parrying though.
+	wdefense = 1	// Akin to a cudgel, still terrible at parrying though.
 
 /obj/item/rogueweapon/whip/xylix
 	name = "cackle lash"
 	desc = "The chimes of this whip are said to sound as the trickster's laughter itself."
 	icon_state = "xylixwhip"
-	force = 24
+	force = 22
 
 /obj/item/rogueweapon/whip/antique
-	force = 29
+	force = 23
 	name = "Repenta En"
 	desc = "An extremely well maintained whip, with a polished steel tip and gilded handle"
 	minstr = 11
@@ -317,6 +352,6 @@
 	desc = "In another lyfe, this humble thresher was used to pound stalks into grain. Under a militiaman's grasp, however, it has found a new purpose: to humble overconfident bandits with crippling blows."
 	icon_state = "milflail"
 	possible_item_intents = list(/datum/intent/flail/strike, /datum/intent/flail/strike/smash/militia)
-	force = 27
+	force = 25
 	wdefense = 3
 	wbalance = WBALANCE_HEAVY

--- a/code/game/objects/items/rogueweapons/melee/knives.dm
+++ b/code/game/objects/items/rogueweapons/melee/knives.dm
@@ -36,6 +36,17 @@
 	clickcd = 8
 	item_d_type = "stab"
 
+/datum/intent/dagger/thrust/pick
+	name = "icepick stab"
+	icon_state = "inpick"
+	attack_verb = list("stabs", "impales")
+	hitsound = list('sound/combat/hits/bladed/genstab (1).ogg', 'sound/combat/hits/bladed/genstab (2).ogg', 'sound/combat/hits/bladed/genstab (3).ogg')
+	penfactor = 70
+	clickcd = 14
+	swingdelay = 12
+	damfactor = 1.1
+	blade_class = BCLASS_PICK
+
 /datum/intent/dagger/thrust/seax
 	damfactor = 0.9
 	penfactor = 30

--- a/code/game/objects/items/rogueweapons/melee/knives.dm
+++ b/code/game/objects/items/rogueweapons/melee/knives.dm
@@ -10,11 +10,19 @@
 	animname = "cut"
 	blade_class = BCLASS_CUT
 	hitsound = list('sound/combat/hits/bladed/smallslash (1).ogg', 'sound/combat/hits/bladed/smallslash (2).ogg', 'sound/combat/hits/bladed/smallslash (3).ogg')
+	damfactor = 0.85
 	penfactor = 0
 	chargetime = 0
 	swingdelay = 0
 	clickcd = 10
 	item_d_type = "slash"
+
+/datum/intent/dagger/cut/knife
+	damfactor = 1
+
+/datum/intent/dagger/cut/stiletto
+	damfactor = 0.55
+	blade_class = BCLASS_BLUNT // It has blunt edges, it's purely designed for stabbing.
 
 /datum/intent/dagger/thrust
 	name = "thrust"
@@ -28,26 +36,34 @@
 	clickcd = 8
 	item_d_type = "stab"
 
-/datum/intent/dagger/thrust/pick
+/datum/intent/dagger/thrust/seax
+	damfactor = 0.9
+	penfactor = 30
+
+/datum/intent/dagger/thrust/stiletto
+	damfactor = 1.05
+	penfactor = 80
+
+/datum/intent/dagger/thrust
 	name = "icepick stab"
 	icon_state = "inpick"
 	attack_verb = list("stabs", "impales")
 	hitsound = list('sound/combat/hits/bladed/genstab (1).ogg', 'sound/combat/hits/bladed/genstab (2).ogg', 'sound/combat/hits/bladed/genstab (3).ogg')
-	penfactor = 80
+	penfactor = 70
 	clickcd = 14
 	swingdelay = 12
 	damfactor = 1.1
 	blade_class = BCLASS_PICK
 
 /datum/intent/dagger/sucker_punch
-	name = "sucker punch"
-	icon_state = "inpunch"
-	attack_verb = list("punches", "jabs",)
+	name = "sucker hilt"
+	icon_state = "instrike"
+	attack_verb = list("hilt pommels", "hilt jabs",)
 	animname = "strike"
 	blade_class = BCLASS_BLUNT
 	hitsound = list('sound/combat/hits/blunt/bluntsmall (1).ogg', 'sound/combat/hits/blunt/bluntsmall (2).ogg', 'sound/combat/hits/kick/kick.ogg')
 	damfactor = 1
-	penfactor = BLUNT_DEFAULT_PENFACTOR
+	penfactor = 10
 	clickcd = 14
 	recovery = 10
 	item_d_type = "blunt"
@@ -71,11 +87,18 @@
 	hitsound = list('sound/combat/hits/bladed/genchop (1).ogg', 'sound/combat/hits/bladed/genchop (2).ogg', 'sound/combat/hits/bladed/genchop (3).ogg')
 	penfactor = 30
 
+/datum/intent/dagger/chop/cleaver/seax
+	name = "seax chop"
+	penfactor = 25
+	damfactor = 1.35
+	swingdelay = 3.5
+	clickcd = 9.05
+
 //knife and dagger objs ฅ^•ﻌ•^ฅ
 
 /obj/item/rogueweapon/huntingknife
 	force = 12
-	possible_item_intents = list(/datum/intent/dagger/cut, /datum/intent/dagger/thrust, /datum/intent/dagger/chop)
+	possible_item_intents = list(/datum/intent/dagger/cut/knife, /datum/intent/dagger/thrust, /datum/intent/dagger/chop)
 	slot_flags = ITEM_SLOT_HIP|ITEM_SLOT_MOUTH
 	name = "hunting knife"
 	desc = "A hunter's prized possession. Keep it sharp, and it might last you through the wild."
@@ -142,7 +165,7 @@
 	force = 15
 	name = "cleaver"
 	desc = "Chop, chop, chop!"
-	possible_item_intents = list(/datum/intent/dagger/cut, /datum/intent/dagger/chop/cleaver)
+	possible_item_intents = list(/datum/intent/dagger/cut/knife, /datum/intent/dagger/chop/cleaver)
 	icon_state = "cleaver"
 	icon = 'icons/roguetown/weapons/32.dmi'
 	parrysound = list('sound/combat/parry/bladed/bladedmedium (1).ogg','sound/combat/parry/bladed/bladedmedium (2).ogg','sound/combat/parry/bladed/bladedmedium (3).ogg')
@@ -186,7 +209,7 @@
 	force = 15
 	name = "chef's knife"
 	desc = "Keep it in the kitchen!"
-	possible_item_intents = list(/datum/intent/dagger/cut, /datum/intent/dagger/chop/cleaver, /datum/intent/dagger/thrust)
+	possible_item_intents = list(/datum/intent/dagger/cut/knife, /datum/intent/dagger/chop/cleaver, /datum/intent/dagger/thrust)
 	icon_state = "chefsknife"
 	icon = 'icons/roguetown/weapons/32.dmi'
 	parrysound = list('sound/combat/parry/bladed/bladedmedium (1).ogg','sound/combat/parry/bladed/bladedmedium (2).ogg','sound/combat/parry/bladed/bladedmedium (3).ogg')
@@ -198,11 +221,11 @@
 	smeltresult = /obj/item/ingot/steel
 
 /obj/item/rogueweapon/huntingknife/combat
-	force = 16
+	force = 16.5
 	name = "seax"
 	desc = "A fighting knife used amongst the Grenzels and Northerners for centuries, serving dual purpose as a \
 	tool of daily life and as a capable fighting knife."
-	possible_item_intents = list(/datum/intent/dagger/cut, /datum/intent/dagger/chop/cleaver, /datum/intent/dagger/sucker_punch,)
+	possible_item_intents = list(/datum/intent/dagger/cut/knife, /datum/intent/dagger/thrust/seax, /datum/intent/dagger/chop/cleaver/seax, /datum/intent/dagger/sucker_punch,)
 	icon_state = "combatknife"
 	icon = 'icons/roguetown/weapons/32.dmi'
 	parrysound = list('sound/combat/parry/bladed/bladedmedium (1).ogg','sound/combat/parry/bladed/bladedmedium (2).ogg','sound/combat/parry/bladed/bladedmedium (3).ogg')
@@ -249,14 +272,14 @@
 	name = "steel dagger"
 	desc = "This is a dagger made of solid steel, more durable."
 	icon_state = "sdagger"
-	force = 20
+	force = 18.5
 	max_integrity = 150
 	smeltresult = /obj/item/ingot/steel
 
 /obj/item/rogueweapon/huntingknife/idagger/steel/holysee
 	name = "eclipsum dagger"
 	desc = "A blade forged from the Holy metals of the twinned gods Noc and Astrata, Silver and Gold fused under an Eclipse and blessed, these daggers are very grudgingly given out by the Grenzelhoftian See to ordained Priests of the Ten."
-	force = 25
+	force = 23
 	max_integrity = 200
 	icon_state = "gsdagger"
 
@@ -269,27 +292,29 @@
 
 
 /obj/item/rogueweapon/huntingknife/idagger/dtace
+	possible_item_intents = list(/datum/intent/dagger/thrust/stiletto, /datum/intent/dagger/cut/stiletto, /datum/intent/dagger/thrust/pick, /datum/intent/dagger/sucker_punch)
 	name = "'De Tace'"
 	desc = "The right hand of the right hand, this narrow length of steel serves as a quick solution to petty greviences."
 	icon_state = "stiletto"
-	force = 25
+	force = 20
 	max_integrity = 200
 	smeltresult = /obj/item/ingot/steel
 
-/obj/item/rogueweapon/huntingknife/idagger/steel/parrying //direct upgrade but more costly.
+/obj/item/rogueweapon/huntingknife/idagger/steel/parrying
 	name = "steel parrying dagger"
 	desc = "This is a parrying dagger made of solid steel, used to catch opponent's weapons in the handguard, but it's not as good for actual stabbing work."
-	force = 15
-	throwforce = 15
+	force = 14
+	throwforce = 14
 	icon_state = "spdagger"
 	wdefense = 6
 
 /obj/item/rogueweapon/huntingknife/idagger/steel/parrying/vaquero
+	possible_item_intents = list(/datum/intent/dagger/thrust, /datum/intent/dagger/cut/stiletto, /datum/intent/dagger/thrust/pick, /datum/intent/dagger/sucker_punch)
 	name = "sail dagger"
 	desc = "An exceptionally protective parrying dagger popular in the Etruscan Isles, this dagger features a plain metal guard in the shape of a ship's sail."
 	wdefense = 7
-	force = 17
-	throwforce = 17
+	force = 16
+	throwforce = 16
 	icon_state = "sail_dagger"
 
 /obj/item/rogueweapon/huntingknife/idagger/steel/special
@@ -381,7 +406,7 @@
 /obj/item/rogueweapon/huntingknife/idagger/silver/elvish
 	name = "elvish dagger"
 	desc = "This beautiful dagger is of intricate, elvish design. Sharper, too."
-	force = 22
+	force = 21
 	icon_state = "elfdagger"
 	item_state = "elfdag"
 	last_used = 0
@@ -390,12 +415,12 @@
 /obj/item/rogueweapon/huntingknife/idagger/silver/elvish/drow
 	name = "drowish dagger"
 	desc = "A vicious wave-bladed dagger from the Underdark."
-	force = 25
+	force = 22.5
 	last_used = 0
 	is_silver = TRUE
 
 /obj/item/rogueweapon/huntingknife/idagger/navaja
-	possible_item_intents = list(/datum/intent/dagger/thrust,/datum/intent/dagger/cut,  /datum/intent/dagger/thrust/pick)
+	possible_item_intents = list(/datum/intent/dagger/thrust,/datum/intent/dagger/cut/knife, /datum/intent/dagger/thrust/pick)
 	name = "navaja"
 	desc = "A folding Etruscan knife valued by merchants, mercenaries and peasants for its convenience. It possesses a long hilt, allowing for a sizeable blade with good reach."
 	force = 5
@@ -409,10 +434,10 @@
 	extended = !extended
 	playsound(src.loc, 'sound/blank.ogg', 50, TRUE)
 	if(extended)
-		force = 20
-		wdefense = 6
+		force = 19
+		wdefense = 4
 		w_class = WEIGHT_CLASS_NORMAL
-		throwforce = 23
+		throwforce = 22
 		icon_state = "navaja_o"
 		attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 		sharpness = IS_SHARP
@@ -463,9 +488,9 @@
 	name = "steel tossblade"
 	desc = "There are rumors of some sea-marauders loading these into metal tubes with explosive powder to launch then fast and far. Probably won't catch on."
 	item_state = "bone_dagger"
-	throwforce = 28
+	throwforce = 20
 	max_integrity = 100
-	armor_penetration = 40
+	armor_penetration = 20
 	icon_state = "throw_knifes"
 	embedding = list("embedded_pain_multiplier" = 4, "embed_chance" = 30, "embedded_fall_chance" = 5)
 	sellprice = 2
@@ -480,8 +505,8 @@
 	desc = "An unconventional method of delivering silver to a heretic; but one that the Ten smile at, all the same. Doubles as an actual knife in a pinch, though obviously not as well."
 	item_state = "bone_dagger"
 	force = 12
-	throwforce = 28
-	armor_penetration = 50
+	throwforce = 20
+	armor_penetration = 25
 	max_integrity = 150
 	wdefense = 3
 	icon_state = "throw_knifep"

--- a/code/game/objects/items/rogueweapons/melee/polearms.dm
+++ b/code/game/objects/items/rogueweapons/melee/polearms.dm
@@ -10,7 +10,7 @@
 	chargetime = 1
 	warnie = "mobwarning"
 	hitsound = list('sound/combat/hits/bladed/genstab (1).ogg', 'sound/combat/hits/bladed/genstab (2).ogg', 'sound/combat/hits/bladed/genstab (3).ogg')
-	penfactor = 50
+	penfactor = 45
 	item_d_type = "stab"
 
 /datum/intent/spear/thrust/militia
@@ -20,7 +20,6 @@
 /datum/intent/spear/bash
 	name = "bash"
 	blade_class = BCLASS_BLUNT
-	penfactor = BLUNT_DEFAULT_PENFACTOR
 	icon_state = "inbash"
 	attack_verb = list("bashes", "strikes")
 	penfactor = 10
@@ -37,23 +36,29 @@
 	icon_state = "incut"
 	damfactor = 0.8
 	hitsound = list('sound/combat/hits/bladed/genslash (1).ogg', 'sound/combat/hits/bladed/genslash (2).ogg', 'sound/combat/hits/bladed/genslash (3).ogg')
+	swingdelay = 5
 	reach = 2
 	item_d_type = "slash"
 
 /datum/intent/spear/cut/halberd
 	damfactor = 0.9
+	chargetime = 0
+	swingdelay = 3
+	penfactor = 10
 
 /datum/intent/spear/cut/scythe
 	reach = 3
 	damfactor = 1
 
 /datum/intent/spear/cut/bardiche
-    damfactor = 1.2
+    damfactor = 1.15
     chargetime = 0
+	swingdelay = 3.5
 
 /datum/intent/spear/cut/glaive
-	damfactor = 1.2
+	damfactor = 1.1
 	chargetime = 0
+	swingdelay = 2.5
 
 /datum/intent/spear/cast
 	name = "cast"
@@ -94,8 +99,9 @@
 	blade_class = BCLASS_BLUNT
 	icon_state = "inbash"
 	attack_verb = list("bashes", "strikes")
-	penfactor = BLUNT_DEFAULT_PENFACTOR
-	damfactor = 1.3
+	penfactor = 25
+	damfactor = 0.9
+	swingdelay = 6
 	item_d_type = "blunt"
 
 
@@ -106,9 +112,10 @@
 	animname = "cut"
 	blade_class = BCLASS_CHOP
 	reach = 1
-	penfactor = BLUNT_DEFAULT_PENFACTOR
-	damfactor = 2.5
+	penfactor = 20
+	damfactor = 1.25
 	chargetime = 10
+	swingdelay = 5
 	no_early_release = TRUE
 	hitsound = list('sound/combat/hits/bladed/genslash (1).ogg', 'sound/combat/hits/bladed/genslash (2).ogg', 'sound/combat/hits/bladed/genslash (3).ogg')
 	item_d_type = "slash"
@@ -116,10 +123,10 @@
 
 /datum/intent/rend/reach
 	name = "long rend"
-	penfactor = BLUNT_DEFAULT_PENFACTOR
-	misscost = 5
+	penfactor = 25
 	chargetime = 5
-	damfactor = 2
+	swingdelay = 3
+	damfactor = 1.3
 	reach = 2
 
 /datum/intent/rend/reach/partizan
@@ -129,7 +136,7 @@
 	chargetime = 10
 	swingdelay = 8
 	misscost = 20
-	damfactor = 1.8
+	damfactor = 1.5
 	hitsound = list('sound/combat/hits/bladed/genstab (1).ogg', 'sound/combat/hits/bladed/genstab (2).ogg', 'sound/combat/hits/bladed/genstab (3).ogg')
 	item_d_type = "stab"
 	no_early_release = TRUE
@@ -144,7 +151,7 @@
 	hitsound = list('sound/combat/hits/blunt/metalblunt (1).ogg', 'sound/combat/hits/blunt/metalblunt (2).ogg', 'sound/combat/hits/blunt/metalblunt (3).ogg')
 	chargetime = 2
 	penfactor = 200
-	swingdelay = 5
+	swingdelay = 6
 	damfactor = 0.05
 	item_d_type = "slash"
 	peel_divisor = 4
@@ -156,7 +163,7 @@
 /datum/intent/spear/thrust/quarterstaff
 	blade_class = BCLASS_BLUNT
 	hitsound = list('sound/combat/hits/blunt/bluntsmall (1).ogg', 'sound/combat/hits/blunt/bluntsmall (2).ogg')
-	penfactor = BLUNT_DEFAULT_PENFACTOR
+	penfactor = 5
 	damfactor = 1.3 // Adds up to be slightly stronger than an unenhanced ebeak strike.
 	chargetime = 6 // Meant to be stronger than a bash, but with a delay.
 
@@ -169,22 +176,30 @@
 	attack_verb = list("lances", "runs through", "skewers")
 	animname = "stab"
 	item_d_type = "stab"
-	penfactor = BLUNT_DEFAULT_PENFACTOR // Not a mistake, to prevent it from nuking through armor.
+	penfactor = 40
 	chargetime = 4 SECONDS
-	damfactor = 4 // 80 damage on hit. It is gonna hurt.
+	charging_slowdown = 4
+	damfactor = 2.5
 	reach = 3 // Yep! 3 tiles
-	intdamage_factor = 2 // 4 hits to break coat of plate normally.
+	intdamage_factor = 2
 
 /datum/intent/lance/onehand
-	chargetime = 5 SECONDS
+	chargetime = 6 SECONDS
+	charging_slowdown = 5
 
 //polearm objs ฅ^•ﻌ•^ฅ
+
+/datum/intent/mace/tapstrike/staff
+	name = "tap poke"
+	attack_verb = list("pokes", "probs")
+	animname = "stab"
+	reach = 2
 
 /obj/item/rogueweapon/woodstaff
 	force = 10
 	force_wielded = 15
-	possible_item_intents = list(SPEAR_BASH)
-	gripped_intents = list(SPEAR_BASH,/datum/intent/mace/smash/wood)
+	possible_item_intents = list(SPEAR_BASH, /datum/intent/mace/tapstrike/staff)
+	gripped_intents = list(SPEAR_BASH,/datum/intent/mace/smash/wood, /datum/intent/mace/tapstrike/staff, /datum/intent/mace/tapsmash)
 	name = "wooden staff"
 	desc = "A solid dependable walking stick that allows one to traverse rough terrain with ease, keep the weight off an injured leg, or reliably fend off incoming blows. Perfect for beggars, pilgrims, and mages."
 	icon_state = "woodstaff"
@@ -349,12 +364,22 @@
 /obj/item/rogueweapon/spear/billhook
 	name = "billhook"
 	desc = "A neat hook. Used to pull riders from horses, as well as defend against said horses when used in a proper formation. The reinforcements along it's shaft grant it higher durability against attacks."
+	possible_item_intents = list(/datum/intent/spear/thrust/billhook, SPEAR_BASH) // Bash is for nonlethal takedowns, only targets limbs
+	gripped_intents = list(/datum/intent/spear/thrust/billhook, /datum/intent/spear/thrust/billhook, SPEAR_BASH)
 	icon_state = "billhook"
 	smeltresult = /obj/item/ingot/steel
 	max_blade_int = 200
 	minstr = 8
 	wdefense = 6
 	throwforce = 15
+
+/datum/intent/spear/cut/billhook
+	damfactor = 0.85
+	swingdelay = 2.5
+
+/datum/intent/spear/thrust/billhook
+	chargetime = 1.5
+	penfactor = 50
 
 /obj/item/rogueweapon/spear/improvisedbillhook
 	force = 12
@@ -364,7 +389,7 @@
 	icon_state = "billhook"
 	smeltresult = /obj/item/ingot/iron
 	max_blade_int = 100
-	wdefense = 4
+	wdefense = 4.5
 	throwforce = 10
 
 /obj/item/rogueweapon/spear/stone
@@ -426,20 +451,20 @@
 	walking_stick = TRUE
 	wdefense = 4
 	thrown_bclass = BCLASS_STAB
-	throwforce = 35
+	throwforce = 29
 	resistance_flags = FLAMMABLE
 	pickup_sound = 'modular_helmsguard/sound/sheath_sounds/draw_polearm.ogg'
 	sheathe_sound = 'sound/foley/equip/swordlarge1.ogg'
 
 /obj/item/rogueweapon/fishspear/depthseek //DO NOT ADD RECIPE. MEANT TO BE AN ABYSSORITE RELIC. IDEA COURTESY OF LORDINQPLAS
-	force = 45
+	force = 35
 	name = "blessed depthseeker"
 	desc = "A beautifully crafted weapon, with handle carved of some beast's bone, inlaid with smooth seaglass at pommel and head, with two prongs smithed of fine dwarven steel. The seaglass carving at the head is a masterwork in and of itself, you can feel an abyssal energy radiating off it."
 	icon_state = "depthseek"
 	smeltresult = /obj/item/ingot/blacksteel
 	max_blade_int = 2600
-	wdefense = 8
-	throwforce = 50
+	wdefense = 7
+	throwforce = 35
 
 /obj/item/rogueweapon/fishspear/attack_self(mob/user)
 	if(user.used_intent.type == SPEAR_CAST)
@@ -618,8 +643,8 @@
 /obj/item/rogueweapon/halberd
 	force = 15
 	force_wielded = 30
-	possible_item_intents = list(SPEAR_THRUST, SPEAR_BASH) //bash is for nonlethal takedowns, only targets limbs
-	gripped_intents = list(SPEAR_THRUST, /datum/intent/spear/cut/halberd, /datum/intent/sword/chop, SPEAR_BASH)
+	possible_item_intents = list(/datum/intent/spear/thrust/halberd, SPEAR_BASH) // Bash is for nonlethal takedowns, only targets limbs
+	gripped_intents = list(/datum/intent/spear/thrust/halberd, /datum/intent/spear/cut/halberd, /datum/intent/sword/chop, SPEAR_BASH)
 	name = "halberd"
 	desc = "A steel halberd, the pinnacle of all cumulative melee weapon knowledge. The only downside is the cost, so it's rarely seen outside of the guardsmans' hands. The reinforcements along the shaft provide greater durability."
 	icon_state = "halberd"
@@ -639,9 +664,13 @@
 	associated_skill = /datum/skill/combat/polearms
 	blade_dulling = DULLING_SHAFT_WOOD
 	walking_stick = TRUE
-	wdefense = 6
+	wdefense = 5.5
 	pickup_sound = 'modular_helmsguard/sound/sheath_sounds/draw_polearm.ogg'
 	sheathe_sound = 'sound/foley/equip/swordlarge1.ogg'
+
+/datum/intent/spear/thrust/halberd
+	chargetime = 2
+	penfactor = 55
 
 /obj/item/rogueweapon/halberd/getonmobprop(tag)
 	. = ..()
@@ -664,14 +693,14 @@
 	desc = "A mutual effort of Noc and Astrata's followers, this halberd was forged with both Silver and Gold alike. Blessed to hold strength and bring hope. Whether dae or nite. The reinforced shaft provides greater durability."
 	icon_state = "gsspear"
 	max_integrity = 300
-	force = 20
-	force_wielded = 35
+	force = 18
+	force_wielded = 33
 
 /obj/item/rogueweapon/halberd/bardiche
 	possible_item_intents = list(/datum/intent/spear/thrust/eaglebeak, SPEAR_BASH) //bash is for nonlethal takedowns, only targets limbs
 	gripped_intents = list(/datum/intent/spear/thrust/eaglebeak, /datum/intent/spear/cut/bardiche, /datum/intent/axe/chop, SPEAR_BASH)
 	name = "bardiche"
-	desc = "A beautiful variant of the halberd. Its reinforced shaft provides it with greater durability against attacks."
+	desc = "A beautiful variant of the halberd, focused around cutting and chopping. Its reinforced shaft provides it with greater durability against attacks."
 	icon_state = "bardiche"
 	anvilrepair = /datum/skill/craft/weaponsmithing
 	smeltresult = /obj/item/ingot/iron
@@ -718,7 +747,7 @@
 	anvilrepair = /datum/skill/craft/weaponsmithing
 	smeltresult = /obj/item/ingot/steel
 	max_blade_int = 300
-	wdefense = 9
+	wdefense = 6
 
 /obj/item/rogueweapon/halberd/glaive/getonmobprop(tag)
 	. = ..()
@@ -756,7 +785,7 @@
 	max_blade_int = 300
 	blade_dulling = DULLING_SHAFT_REINFORCED
 	walking_stick = TRUE
-	wdefense = 5
+	wdefense = 2.5
 	wbalance = WBALANCE_HEAVY
 	sellprice = 60
 	intdamage_factor = 1.2
@@ -791,16 +820,19 @@
 
 /datum/intent/spear/thrust/eaglebeak
 	penfactor = 20
-	damfactor = 0.9
+	damfactor = 0.8
+	chargetime = 25
+
 
 /datum/intent/spear/thrust/glaive
-	penfactor = 50
-	damfactor = 1.1
+	penfactor = 40
+	damfactor = 1.05
 	chargetime = 0
+	swingdelay = 2
 
 /datum/intent/mace/smash/eaglebeak
 	reach = 2
-	swingdelay = 12
+	swingdelay = 16 // 12 > 16 because it kept bypassing parries and dodges when used on swift, that and it's strong as is.
 	clickcd = 14
 
 /obj/item/rogueweapon/spear/bronze
@@ -1030,7 +1062,7 @@
 	desc = "A staff that makes any journey easier. Durable and swift, capable of bludgeoning stray volves and ruffians alike. Its length allow it to be used for a thrusting attack."
 	force = 15
 	force_wielded = 20
-	gripped_intents = list(/datum/intent/spear/bash/ranged/quarterstaff, /datum/intent/spear/thrust/quarterstaff)
+	gripped_intents = list(/datum/intent/spear/bash/ranged/quarterstaff, /datum/intent/spear/thrust/quarterstaff, /datum/intent/mace/tapstrike/staff, /datum/intent/mace/tapsmash)
 	icon_state = "quarterstaff"
 	max_integrity = 300
 
@@ -1067,7 +1099,7 @@
 	icon = 'icons/roguetown/weapons/64.dmi'
 	minstr = 10
 	max_blade_int = 200
-	wdefense = 6
+	wdefense = 5
 	throwforce = 12	//Not a throwing weapon. Too heavy!
 	blade_dulling = DULLING_SHAFT_REINFORCED
 	icon_angle_wielded = 50
@@ -1088,7 +1120,7 @@
 	icon = 'icons/roguetown/weapons/polearms64.dmi'
 	icon_state = "boarspear"
 	force_wielded = 33 // 10% base damage increase
-	wdefense = 6 // A little bit extra
+	wdefense = 5
 	max_blade_int = 150 // 50% more sharpness but it barely matter lol
 
 /obj/item/rogueweapon/spear/lance
@@ -1097,9 +1129,9 @@
 	the shaft on impact. "
 	icon = 'icons/roguetown/weapons/polearms64.dmi'
 	icon_state = "lance"
-	force = 15 // Its gonna sucks for 1 handed use
+	force = 5 // This isn't meant to be used one-handed.
 	force_wielded = 20 // Lower damage because a 3 tiles thrust without full charge time still deal base damage. 
-	wdefense = 4 // 2 Lower than spear
+	wdefense = 2 // If you have to parry with this unwieldy thing to begin with, oofh, besides you can't parry on horseback anyhow.
 	max_integrity = 200
 	max_blade_int = 200 // Better sharpness
 	possible_item_intents = list(SPEAR_THRUST, /datum/intent/lance/onehand, SPEAR_BASH) //bash is for nonlethal takedowns, only targets limbs

--- a/code/game/objects/items/rogueweapons/melee/polearms.dm
+++ b/code/game/objects/items/rogueweapons/melee/polearms.dm
@@ -53,7 +53,6 @@
 /datum/intent/spear/cut/bardiche
     damfactor = 1.15
     chargetime = 0
-	swingdelay = 3.5
 
 /datum/intent/spear/cut/glaive
 	damfactor = 1.1

--- a/code/game/objects/items/rogueweapons/melee/polearms.dm
+++ b/code/game/objects/items/rogueweapons/melee/polearms.dm
@@ -51,8 +51,8 @@
 	damfactor = 1
 
 /datum/intent/spear/cut/bardiche
-    damfactor = 1.15
-    chargetime = 0
+	damfactor = 1.15
+	chargetime = 0
 	swingdelay = 3.5
 
 /datum/intent/spear/cut/glaive
@@ -103,7 +103,6 @@
 	damfactor = 0.9
 	swingdelay = 6
 	item_d_type = "blunt"
-
 
 /datum/intent/rend
 	name = "rend"

--- a/code/game/objects/items/rogueweapons/melee/polearms.dm
+++ b/code/game/objects/items/rogueweapons/melee/polearms.dm
@@ -53,6 +53,7 @@
 /datum/intent/spear/cut/bardiche
     damfactor = 1.15
     chargetime = 0
+	swingdelay = 3.5
 
 /datum/intent/spear/cut/glaive
 	damfactor = 1.1

--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -1,5 +1,5 @@
-//intent datums ฅ^•ﻌ•^ฅ
-
+//intent datums ฅ^•ﻌ•^ฅ | Ctrl+f keywords, Cut/stab/chop/strike/peel/peel-big-intent]*/
+/*[Cut-intent]*/
 /datum/intent/sword/cut
 	name = "cut"
 	icon_state = "incut"
@@ -11,18 +11,18 @@
 	swingdelay = 0
 	damfactor = 1.1
 	item_d_type = "slash"
-
+/*[Cut-militia-intent]*/
 /datum/intent/sword/cut/militia
 	penfactor = 30
 	damfactor = 1.2
 	chargetime = 0.2
-
+/*[Chop-militia-intent]*/
 /datum/intent/sword/chop/militia
 	penfactor = 50
 	chargetime = 0.5
 	swingdelay = 0
 	damfactor = 1.0
-
+/*[Stab-intent]*/
 /datum/intent/sword/thrust
 	name = "stab"
 	icon_state = "instab"
@@ -34,10 +34,10 @@
 	chargetime = 0
 	swingdelay = 0
 	item_d_type = "stab"
-
+/*[Stab-krieg-intent]*/
 /datum/intent/sword/thrust/krieg
 	damfactor = 0.9
-
+/*[Strike-intent]*/
 /datum/intent/sword/strike
 	name = "pommel strike"
 	icon_state = "instrike"
@@ -50,7 +50,21 @@
 	swingdelay = 0
 	damfactor = 1
 	item_d_type = "blunt"
-
+/*[Peel-small-intent]*/
+/datum/intent/sword/peel/small
+	name = "armor peel"
+	icon_state = "inpeel"
+	attack_verb = list("peels", "chips")
+	animname = "cut"
+	blade_class = BCLASS_PEEL
+	hitsound = list('sound/combat/hits/blunt/metalblunt (1).ogg', 'sound/combat/hits/blunt/metalblunt (2).ogg', 'sound/combat/hits/blunt/metalblunt (3).ogg')
+	chargetime = 0
+	penfactor = 200
+	swingdelay = 2.5
+	damfactor = 0.05
+	item_d_type = "slash"
+	peel_divisor = 7
+/*[Peel-intent]*/
 /datum/intent/sword/peel
 	name = "armor peel"
 	icon_state = "inpeel"
@@ -60,16 +74,17 @@
 	hitsound = list('sound/combat/hits/blunt/metalblunt (1).ogg', 'sound/combat/hits/blunt/metalblunt (2).ogg', 'sound/combat/hits/blunt/metalblunt (3).ogg')
 	chargetime = 0
 	penfactor = 200
-	swingdelay = 0
+	swingdelay = 3.5
 	damfactor = 0.05
 	item_d_type = "slash"
-	peel_divisor = 4
-
+	peel_divisor = 5
+/*[Peel-big-intent]*/
 /datum/intent/sword/peel/big
 	name = "big sword armor peel"
-	peel_divisor = 3
-	reach = 2
-
+	peel_divisor = 4
+	swingdelay = 4.5
+//	reach = 2 // Being both able to hit less times and from afar is a tad much.
+/*[Chop-intent]*/
 /datum/intent/sword/chop
 	name = "chop"
 	icon_state = "inchop"
@@ -77,16 +92,17 @@
 	animname = "chop"
 	blade_class = BCLASS_CHOP
 	hitsound = list('sound/combat/hits/bladed/genchop (1).ogg', 'sound/combat/hits/bladed/genchop (2).ogg', 'sound/combat/hits/bladed/genchop (3).ogg')
-	penfactor = 30
+	penfactor = 15
 	swingdelay = 8
-	damfactor = 1.0
+	damfactor = 0.8
 	item_d_type = "slash"
 
 /datum/intent/sword/cut/falx
-	penfactor = 20
+	penfactor = 15
+	clickcd = 10.5
 
 /datum/intent/sword/chop/falx
-	penfactor = 40
+	penfactor = 20
 
 /datum/intent/sword/cut/krieg
 	clickcd = 10
@@ -103,8 +119,8 @@
 	name = "arming sword"
 	desc = "A long steel blade attached to a hilt, separated by a crossguard. The arming sword has been Psydonia's implement of war by excellence for generations."
 	slot_flags = ITEM_SLOT_HIP | ITEM_SLOT_BACK
-	force = 22
-	force_wielded = 25
+	force = 16
+	force_wielded = 23
 	possible_item_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust, /datum/intent/sword/peel)
 	gripped_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust, /datum/intent/sword/strike, /datum/intent/sword/peel)
 	armor = ARMOR_SWORD
@@ -165,7 +181,7 @@
 /obj/item/rogueweapon/sword/falx
 	name = "falx"
 	desc = "An unusual type of curved sword that evolved from the farmer's sickle. It has an inwards edge, making it useful for cutting and chopping."
-	force = 22
+	force = 19
 	possible_item_intents = list(/datum/intent/sword/cut/falx,  /datum/intent/sword/chop/falx, /datum/intent/sword/strike, /datum/intent/sword/peel)
 	icon_state = "falx"
 	max_blade_int = 100
@@ -199,7 +215,7 @@
 				return list("shrink" = 0.5,"sx" = -4,"sy" = -6,"nx" = 5,"ny" = -6,"wx" = 0,"wy" = -6,"ex" = -1,"ey" = -6,"nturn" = 100,"sturn" = 156,"wturn" = 90,"eturn" = 180,"nflip" = 0,"sflip" = 0,"wflip" = 0,"eflip" = 0,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)
 
 /obj/item/rogueweapon/sword/stone
-	force = 17 //Weaker than a short sword
+	force = 17 // Weaker than a short sword.
 	possible_item_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust, /datum/intent/sword/chop)
 	gripped_intents = null
 	name = "stone sword"
@@ -216,7 +232,7 @@
 /obj/item/rogueweapon/sword/short
 	name = "steel shortsword"
 	desc = "The arming sword's shorter and much older brother. Despite being centuries older than the swords of todae, it remains in use as a cheap sidearm for shieldbearers and archers."
-	force = 19
+	force = 18
 	possible_item_intents = list(/datum/intent/sword/cut/short, /datum/intent/sword/thrust/short, /datum/intent/sword/peel)
 	icon_state = "swordshort"
 	gripped_intents = null
@@ -238,8 +254,8 @@
 	name = "longsword"
 	desc = "A lethal and perfectly balanced weapon. The longsword is the protagonist of endless tales and myths all across Psydonia, seen in the hands of noblemen and an ever-decreasing quantity of master duelists.\
 		 It has great cultural significance in the empires of Grenzelhoft and Etrusca, where legendary swordsmen have created and perfected many fighting techniques of todae."
-	force = 25
-	force_wielded = 30
+	force = 19
+	force_wielded = 27
 	possible_item_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust, /datum/intent/sword/strike, /datum/intent/sword/peel)
 	gripped_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust, /datum/intent/sword/peel, /datum/intent/sword/chop)
 	alt_intents = list(/datum/intent/effect/daze, /datum/intent/sword/strike, /datum/intent/sword/bash)
@@ -313,8 +329,8 @@
 /obj/item/rogueweapon/sword/long/heirloom
 	name = "old longsword"
 	desc = "A very old steel longsword that has since become a showpiece. Perhaps a family relic, or the weapon of a dead knight."
-	force = 20
-	force_wielded = 32
+	force = 18
+	force_wielded = 28
 	possible_item_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust, /datum/intent/sword/strike)
 	gripped_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust, /datum/intent/sword/strike, /datum/intent/sword/chop)
 	icon_state = "heirloom"
@@ -383,11 +399,11 @@
 			if("onbelt") 
 				return list("shrink" = 0.4,"sx" = -4,"sy" = -6,"nx" = 5,"ny" = -6,"wx" = 0,"wy" = -6,"ex" = -1,"ey" = -6,"nturn" = 100,"sturn" = 156,"wturn" = 90,"eturn" = 180,"nflip" = 0,"sflip" = 0,"wflip" = 0,"eflip" = 0,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)
 
-/obj/item/rogueweapon/sword/long/judgement/ascendant //meant to be insanely OP; solo antag wep
+/obj/item/rogueweapon/sword/long/judgement/ascendant // Meant to be insanely OP; solo antag wep (Noooh)
 	name = "\"The Redentor\""
 	desc = "An intricately forged sword of great power. And the preacher said: \"For the Lord is my tower, and He gives me the power to tear down the works of the enemy.\""
-	force = 50
-	force_wielded = 70
+	force = 35
+	force_wielded = 50
 	possible_item_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust, /datum/intent/sword/strike)
 	gripped_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust, /datum/intent/sword/strike, /datum/intent/sword/chop)
 	icon_state = "crucified"
@@ -417,8 +433,8 @@
 /obj/item/rogueweapon/sword/long/vlord
 	name = "\"Ichor Fang\""
 	desc = "An unholy longsword made of odd steel. A green crystalline mass covers the blade and pommel, its edges and serrations tougher and sharper than anything forged by a master swordsmith."
-	force = 40
-	force_wielded = 55
+	force = 30
+	force_wielded = 45
 	possible_item_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust, /datum/intent/sword/peel, /datum/intent/sword/strike)
 	gripped_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust, /datum/intent/sword/strike, /datum/intent/sword/chop)
 	alt_intents = list(/datum/intent/effect/daze, /datum/intent/sword/strike, /datum/intent/sword/bash)
@@ -462,8 +478,8 @@
 /obj/item/rogueweapon/sword/sabre/shamshir
 	name = "shamshir"
 	desc = "A curved one-handed longsword. This type of scimitar is the quintessential armament of Shalvistine horsemen, its name derived from Sama'glos for \"Tiger's claw\"."
-	force = 24
-	wdefense = 6.5	//Has chop mode, so slightly less defense. Slightly.
+	force = 19
+	wdefense = 6.5	// Has chop mode, so slightly less defense. Slightly.
 	wbalance = WBALANCE_SWIFT
 	icon_state = "tabi"
 	max_integrity = 230
@@ -495,9 +511,9 @@
 /obj/item/rogueweapon/sword/long/marlin
 	name = "shalal saber"
 	desc = "A large yet surprisingly agile curved blade meant to be wielded in two hands. It has a similar composition to northwestern Psydonian longswords, but it's notably lighter."
-	force = 26
-	force_wielded = 31
-	possible_item_intents = list(/datum/intent/sword/cut, /datum/intent/sword/strike, /datum/intent/sword/peel)
+	force = 17.5
+	force_wielded = 29
+	possible_item_intents = list(/datum/intent/sword/cut, /datum/intent/sword/strike, /datum/intent/sword/peel/small)
 	gripped_intents = list(/datum/intent/sword/cut, /datum/intent/sword/strike, /datum/intent/sword/chop, /datum/intent/sword/peel)
 	icon_state = "marlin"
 	max_integrity = 235
@@ -535,19 +551,21 @@
 			if("onbelt")
 				return list("shrink" = 0.5,"sx" = -4,"sy" = -6,"nx" = 5,"ny" = -6,"wx" = 0,"wy" = -6,"ex" = -1,"ey" = -6,"nturn" = 100,"sturn" = 156,"wturn" = 90,"eturn" = 180,"nflip" = 0,"sflip" = 0,"wflip" = 0,"eflip" = 0,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)
 
-//Slightly more expensive than a longsword by 1 iron, so gets to be slightly better.
+// Slightly more expensive than a longsword by 1 iron, so gets to be slightly better.
 /obj/item/rogueweapon/sword/long/exe
 	name = "executioners sword"
 	desc = "A longsword with extra heft to its blade, reinforced."
-	possible_item_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust, /datum/intent/sword/peel, /datum/intent/sword/strike)
-	gripped_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust, /datum/intent/sword/strike, /datum/intent/axe/chop)
+	force = 15
+	force_wielded = 30
+	possible_item_intents = list(/datum/intent/sword/strike)
+	gripped_intents = list(/datum/intent/axe/chop, /datum/intent/sword/thrust/exe, /datum/intent/sword/strike)
 	icon_state = "exe"
 	minstr = 12
-	slot_flags = ITEM_SLOT_BACK //Too big for hip
+	slot_flags = ITEM_SLOT_BACK // Too big for hip
 
 /datum/intent/sword/thrust/exe
-	swingdelay = 4	//Slight delay to stab; big and heavy.
-	penfactor = 30	//Slightly better pen than base longsword, which is 20. It's a heavy blade so.
+	swingdelay = 8	// Think of it as a one two motion.
+	penfactor = 30	// Slightly better pen than base longsword, which is 20. It's a heavy blade so.
 
 /obj/item/rogueweapon/sword/long/exe/astrata
 	name = "\"Solar Judge\""
@@ -594,6 +612,8 @@
 	name = "iron arming sword"
 	desc = "A long iron blade attached to a hilt, separated by a crossguard. The arming sword has been Psydonia's implement of war by excellence for generations, this one is cheaper than its steel brother."
 	icon_state = "isword"
+	force = 16
+	force_wielded = 23
 	minstr = 6
 	smeltresult = /obj/item/ingot/iron
 	max_integrity = 135
@@ -690,16 +710,21 @@
 	icon_state = "smesser"
 	max_integrity = 180
 	force = 22	//Same damage as the iron messer
-	possible_item_intents = list(/datum/intent/sword/cut/sabre, /datum/intent/sword/thrust, /datum/intent/axe/chop, /datum/intent/sword/peel)
+	possible_item_intents = list(/datum/intent/sword/cut/sabre, /datum/intent/sword/thrust/messer, /datum/intent/axe/chop, /datum/intent/sword/peel)
 	gripped_intents = null
 	minstr = 5
+
+/datum/intent/sword/thrust/messer
+	damfactor = 0.9
+	penfactor = 25
+	swingdelay = 6
 
 /obj/item/rogueweapon/sword/sabre
 	name = "sabre"
 	desc = "A very popular backsword made for cavalrymen that originated in Naledi and spread its influence further north, reaching Aavnr as a \"Szablya\" and notoriously cementing itself as the preferred weapon of the Potentate's Hussars."
 	icon_state = "saber"
 	max_integrity = 230
-	possible_item_intents = list(/datum/intent/sword/cut/sabre, /datum/intent/sword/thrust/sabre, /datum/intent/sword/peel, /datum/intent/sword/strike)
+	possible_item_intents = list(/datum/intent/sword/cut/sabre, /datum/intent/sword/thrust/sabre, /datum/intent/sword/peel/small, /datum/intent/sword/strike)
 	gripped_intents = null
 	parrysound = list('sound/combat/parry/bladed/bladedthin (1).ogg', 'sound/combat/parry/bladed/bladedthin (2).ogg', 'sound/combat/parry/bladed/bladedthin (3).ogg')
 	swingsound = BLADEWOOSH_SMALL
@@ -708,13 +733,12 @@
 	wbalance = WBALANCE_SWIFT
 
 /datum/intent/sword/cut/sabre
-	clickcd = 8			//Faster than sword by 4
-	damfactor = 1.25	//Better than rapier (Base is 1.1 for swords)
-	penfactor = 10		//Very slight buff to pen on cut mode. Still weaker than sword-chop mode.
+	clickcd = 8			// Faster than sword by 4
+	penfactor = 10		// Very slight buff to pen on cut mode. Still weaker than sword-chop mode.
 
 /datum/intent/sword/thrust/sabre
-	clickcd = 9			//Fast but just shy of being as good as a rapier by 1.
-	damfactor = 0.9		//10% worse	than base
+	clickcd = 9.5		// Fast but just shy of being as good as a rapier by 1.5.
+	damfactor = 0.9		// 10% worse than base
 
 /obj/item/rogueweapon/sword/sabre/dec
 	icon_state = "decsaber"
@@ -910,12 +934,15 @@
 	desc = "The mariner's special: A short, broad sabre with a slightly curved blade optimized for slashing."
 	icon_state = "cutlass"
 	max_integrity = 240
-	force = 23
-	possible_item_intents = list(/datum/intent/sword/cut, /datum/intent/sword/chop, /datum/intent/sword/peel)
+	force = 20
+	possible_item_intents = list(/datum/intent/sword/cut/cutlass, /datum/intent/sword/chop, /datum/intent/sword/peel)
 	gripped_intents = null
 	wdefense = 6.5
-	wbalance = WBALANCE_SWIFT
-	
+
+/datum/intent/sword/cut/cutlass
+	damfactor = 1.15
+	penfactor = 15
+	swingdelay = 4
 
 /obj/item/rogueweapon/sword/silver
 	force = 24
@@ -1170,8 +1197,8 @@
 /obj/item/rogueweapon/sword/long/holysee
 	name = "eclipsum sword"
 	desc = "A deadly longsword born of Astratan and Nocite hands, this blade was forged with both silver and gold alike. Blessed to hold strength and bring hope, whether it be during the dae or the nite."
-	force = 34
-	force_wielded = 50
+	force = 30
+	force_wielded = 40
 	possible_item_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust, /datum/intent/sword/peel, /datum/intent/sword/strike)
 	gripped_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust, /datum/intent/sword/peel, /datum/intent/sword/chop)
 	icon_state = "eclipsum"

--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -94,7 +94,7 @@
 	hitsound = list('sound/combat/hits/bladed/genchop (1).ogg', 'sound/combat/hits/bladed/genchop (2).ogg', 'sound/combat/hits/bladed/genchop (3).ogg')
 	penfactor = 15
 	swingdelay = 8
-	damfactor = 0.8
+	damfactor = 1.2
 	item_d_type = "slash"
 
 /datum/intent/sword/cut/falx

--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -94,7 +94,7 @@
 	hitsound = list('sound/combat/hits/bladed/genchop (1).ogg', 'sound/combat/hits/bladed/genchop (2).ogg', 'sound/combat/hits/bladed/genchop (3).ogg')
 	penfactor = 15
 	swingdelay = 8
-	damfactor = 1.2
+	damfactor = 1.15 // Cut lacks penetration factor for basic swords, the idea of it originally being a lower damage than cut was the critical upside of easier delimbing, the goal was totmake axes to be the best at chopping and axe variant polearms, if a chopping sword is of interest, use the executioners sword instead.
 	item_d_type = "slash"
 
 /datum/intent/sword/cut/falx


### PR DESCRIPTION
---
# Swords.
Their damage has been reduced, however the cut intent in most cases resumes their prior damage amount if not a tad more.
As a result stabs are weaker, yet more accurate than cuts to balance them out.
Some swords had their defense boosted.
Some swords got better or even worse penetration factor depending on intent.
No swords, not even when wielded (unless its the silly one of a kind ones, not the tavern one) won't be able to immobilize another character, assuming they don't use strong intent or are just a point mightier than average.

- Shorter swords have better stab piercing due to them being easier to fiddle them between armor gaps.
- Normal swords are easier to wield one handed over long swords.
- Long swords have a one-handed penalty. (Basically they deal less brute damage than the prior two if one-handed)

- Sabre cut deals less damage due to it being a thin swift blade, it's stab has been slowed down by a quarter second.
- Cutlass is now the King of one-handed cutting, beware of the delay between cuts however, this in theory should make chasing fleeing targets a tad more difficult, it has okay'ish armor penetration on cut, as a exchange it lost swift balance.
- Executioner's sword has had a intent that was in the code applied with a bit of modification, seemingly a forgotten code piece to be put in, well, not anymore, the executioner's sword also had its intents overhauled.
One-handed: Pommel strike.
Two-handed: chop, executioner thrust, pommel strike.
- The one of a kind swords were brought a tad down to earth, even if they are clearly superior over others.
- - -
# Axes
- Cut's damage was cut down by 10% (Instead of making the attack delayed which would feel awful)
- Chop's penetration taken from 35 to 30.
- Bash had penetration factor applied to 20 from 0.
- The axes are decent choices to be one-handed.
Battle axes and Great axes are ill advised to use with one-hand now that their one-hand damage was pommeled down.
- The battle axe and oath have lost their long-weapon privileges.
- Great axes now have a swing delay of 0.6 second on a cut and 1.2 on a chop. (Range two with little downside is silly)
- The Pulaski axe had its damage reduced by 1 point of brute each grip. (I know, too much)
- Copper hatchet had its damage increased from 13 to 16. (It's one-handed only, it should hurt)
- - -
# Maces.
- Maces had a idea in mind to make themselves different from flails, for example, strike has been delayed by 0.4 second.
- Strike intent lost the 10% extra damage on this intent, and gotten a penetration factor of 20.
- Smash intent has been given 70 penetration factor, due to the maces being made weaker.
This should make armored folk not feel too comfortable, while at the same time not destroying it due to maces having their damage reduced over all, focusing more on getting through armor than raw damage until they get in.
- Mace thrusts now take 1.5 second instead of 1 second. (No one said even spiked ones were designed for the task proper)
- Cudgel had its 1 defense brought down to 0.5 due to it being a tiny thing.
- Cudgel has gained two new intents specifically designed for it and the Marshal stick.
0. The Cudgel has a base damage of 25 brute blunt edition on both one-handed grip and two-handed grip.
1. The Cudgel strike has no swing delay unlike the other maces mixed with 10 penetration factor.
2. The Cudgel smash (when wielded) has a swing delay of 0.6, instead of 1.2, penetration factor 30 instead of 70 of the mace and 25% more damage instead of 50.
- Warclub's one-handed damage increased from 15 to 16.5 because it's bigger.
- Warhammer pick intent from 15 to 20 swing delay. (Should buy enough time to manually dodge it)
- - -
# Knives and Daggers.
- Cut intent on daggers has been reduced by 15%. (It's a dagger, its purpose its stabbing if anything)
- A new intent of cut knife was added that lacks the 15% penalty, think of knives, combat knife, clever.
- Sucker punch has been re-flavored as Sucker hilt with new verbs "hilt pommels", "hilt jabs"
Be advised this attack is slow to recover from, but bypasses parry and dodge checks, yes, you can hit speedie with this.
- The steel dagger's damage has been reduced from 20 to 18.5, it was simply too much to deal the maximum wound type while having fast attacks that bypass parries and dodges on the second hit due to them having the same cooldown as a 1.2 attack, mixed with it simply shadowing the iron variant it was brought down.
- The De Tace' also known as the stiletto, has had some changes done to it.
Its blunt edges lead to blunt cuts that reduce damage, it was designed for stabbing after all,  (Could be used for sparing)
It's the best stabbing dagger your character can find, sporting 5% more damage on its new intent mixed with 80 AP.
- The Seax also known as the combat knife to smiths has had a redesign in how it's used.
Its cut suffers no draw backs that the daggers would normally have.
Its stab does 10% less damage and has a penetration factor of 30, (Not ideal for stabbing basically, but the cleaver lacks it)
Its chop is both weaker in penetration factor by 5 and damage by 15% compared to a cleaver its both faster to land and initiate an attack with, making it far more mobile and most versatile of the knives.
- Parrying/sailing dagger had both of their damages reduced by 1 point in both melee and throwing.
- Elvish dagger damage reduced from 22 to 21.
- Drowish dagger damage reduced from 25 to 22.5 (Quite honestly too much after all the weapons got pulled a tad back)
- Navaja force 20 < 19, throw force 23 < 22, defense 6 to 4.
- Tossblades, throw damaged reduced from 28 to 20, their armor penetration went from 40 to 20. (They can't be parried nor dodged, no need to let the little tossers be able to penetrate pretty much half the armor sets)
- Psydon tossblade, throw damage reduced from 28 to 20, armor penetration 50 reduced to 25. (Like, why?)
- - -
# Flails and whips.
- Strike was given penetration factor 10 while both the iron and steel flail suffered damage reduction to 15, 21.
Unlike the mace strike doesn't suffer any swing delay, same as the cudgel's strike now.
It now also has a ranged strike, that has a 2.5 second delay before it lands even when fully charged up and swung, this should  encourage staying on target instead of getting a cheeky hit in and moving before they can return a strike, this intent also comes packed with penetration factor 20 due to being unable to be spammed (w/ much damage) and proper windup.
- Smash just like strike doesn't have a swing delay however it has a windup first., with 70 penetration factor now.
Smash has a ranged variant with 5 more penetration factor and 5% more damage, with a swing delay of 0.5 second.
- There is an new unused sucker curve that ignores parries, might be added on another PR on an alt intent.
It basically ignores parries but on a reduced damage capacity with swing delay, think of it as curving around parries.
- - -
- All whip intents have been made blunt, except for crack which was turned into stab to not delimb. (Non sense really)
- The "whip" was renamed to the "leather whip".
- All whip verbs have been given a modification to clarify the attack type being used on someone.
- Punish intent now does way less damage, useful for roleplaying cruelty in a mechanical sense.
- Whips no longer do a over the top amount of damage, while both having speed of attacks and range to do it.
- A new intent was added, sucker lash, it's a blunt range 2 attack, 25% less damage, slower to perform than the others, than why use it?; Well, you see, the thing about this is, it's too fast to be parried or dodged, think of it either curving around things to hit them or just too wide to dodge for a reasonable person.
- - -
# Polearms.
- Spear stab reduced in penetration factor by 5 making it 45 instead of 50. (Polearms do a lot of damage as is)
- On most things that use cuts, delays were added on varying degrees depending on the weapon.
Why?; Well this is so, it isn't sword but cheaper with better range, better parry, and terrain penalty negation.
- Rending has been made actually reasonable when it comes to damage, instead of being 70+. (like yikes)
- Some polearms were made better either with cutting or stabbing, varying them up quite a bit, they shouldn't feel all the same as they used to, some will clearly be better for specific play styles, experiment and find out which one is for you.
- Eaglebeak thrust types have been made horrible to perform now taking 2.5 seconds to charge up
- Eagle beak has had its swing delay of 1.2 second increased to 1.6 because swift intent was abused on them, that and quite honestly, if they have both the damage and the range to utterly cripple others they should have something taken away, oh right, their defense was made from 4 to 2.5, it's a hefty weapon it really shouldn't be easy to parry with.
- A list of other parry polearm changes.
Boarspear defense 6 < 5
Improvised billhook, defense 4 > 4.5 (It's still a billhook and a billhook was a farming tool made weapon)
Halberd, defense 6 < 5.5. (It does have a slower charge up thrust that has 55 penetration factor)
Glave, defense 9 < 6. (It's light, with no guards on it, that and its a really fast attacking weapon)
Partizan, defense 6 < 5. (It's heavy or so does the description say, but it does have a guard to hook blades in)
- - -
- The lance has been heavily redesigned, no more one taps on limbs to instantly disabled them even if no crit happens, nor utterly destroying armor with the over the top damage and range with basically no penalty.
-  The lance had the following changes:
Penetration factor from 0 to 40. (It was unable to penetrate armor and utterly destroyed it instead)
Damage factor 4 < 2.5. (It used to do 300% extra damage which was 80 stab, and this was on normal strength)
One-handed damaged reduced from 15 to 5,
Two-handed remained the same at 20,
Defense reduced from 4 to 2. (Your character can't parry while mounted/buckled anyhow, so, this doesn't matter)
And let's be honest, if your character has to parry with this out of all things, they're probably already done for.
Charging slowdown = 5. (One-handed) - (Bigger number means slower)
Charging slowdown = 4. (Two-handed) - (Smaller number means not as slow, zero would be any normal tile)
The above means a mount of some sort is needed to use this effectively. (Ranged weapons have this effect)
- - -
# Peeling.
- A new small peeling type was added requiring 7 peels replacement on those faster weapons. swing delay 0.25.
- Normal peels have been increased to 5. swing delay 0.35 second.
- Heavy peels have been increased to 4 and had their reach two removed from swords. swing delay 0.45.
- I didn't find the system appealing to fight with or against, so, I changed it to be unpeeling to perform.
That and let's be honest, it was heavily based on one on one fights, that usually isn't the case.
- - -
# Play/train fighting.
- The wooden sword/club/staff and even quarter staff have been given new intents that simulate attacks.
These new intents in the code are known as.
/datum/intent/mace/tapstrike
/datum/intent/mace/tapstrike/club
/datum/intent/mace/tapsmash
/datum/intent/mace/tapsmash/sword
They all do 0.1 the original damage of the weapon and mimic the attack speed.
They have verbs of taps, tapped, and for the staves, pokes, probs.
- The goal of this is to make it both fun for those being playful and those that want to train without having to have a healer on stand by for daes or chugging potions to heal or sleep, allowing prolonged practice, if planning to do this on an intent that isn't weak (because yes due to how the code works this can on extremely rare circumstances crit), some light leather or clothed armor is advised. (Again if trying something that isn't on weak intent)
Beware that this does not simulate the slow down when being actually hit due to lack of damage inflicted.
- - -
# Misc.
Some things were reorganized notes wise.
Some weapons not listed have been given their own intents. (dig in the code if interested)
The word hits x with y for both maces and flail were changed to whacks x with y.
- - -
# Possible questions.
Aren't the swords seemingly under powered?
No, they aren't, their cut deals 10% more damage on all of them, giving an motivation to choose between the two, more damage?; Or greater accuracy with armor penetration?
The swords also sport a parrying advantage, and versatility over all.

Isn't the peeling nerf a tad much?
No, it isn't, one, it wasn't fun to play against, two, it is heavily bias against one versus one fights, when usually multiple people are fighting, three, it should be a tad more cumbersome to perform to discourage it.

Why were long swords beaten down?
Because they already can reach everybody part, there's no reason why a long sword should be able, not only have a greater damage amount one and two handed, all body parts within reach standing or laying and taking less damage while parrying.

Why have the axes remained mostly unchanged, besides the nerf to one handed holds on most?
Because they don't have the parrying or accuracy advantages of others, and yes, cut was nerfed a tad due to having two options, add swingdelay so, the damage extra compared to the others make sense, or lower the damage overall, because the former would've made the combat feel off.

Why were the the daggers nerfed in damage?
Well, doing the highest damage wound type by default, attacking faster than someone can parry or dodge on the second hit, bypassing 10% of parry chance if a speed point above the other and stacking, mixed with their storability and lack of variation lead to change of ideas, giving purpose to the other knifes as well.

Why were tossingblades nerfed?
If you have something that you can easily throw, like throw, swap, throw, hotkey pull out new and throw with little in-between, mixed with them being unable to be parried nor dodged and dealing more damage than a thrown spear while being easy to store in mass, they were simply deemed unrealistic and unfun to fight against.
- - -
# Why it's good for the game?
That's a simple question to answer, it not only gives proper balance to weapons, it also gives them a purpose (and to some the exact purpose they were designed for mixed with their exact drawback in a logical sense) this should make it more fair and fun for most people when engaging in combat, fights won't end to swiftly or even too slowly, every weapon gets both a purpose and its own flavor, mixed with intents that add the possibility to playfight or train for a good while be it recreational or serious prolonged training base, it has a little bit for everyone, while balancing some over the top weapons. cough cough lance, cough cough, eaglebeak, with all that said, I do hope everyone has a great dae/night.
- - -
# Proof of testing.
![image](https://github.com/user-attachments/assets/0646cb95-4d74-4968-9676-f8738982eebb)
- - -