### PR TITLE
Psydon Additions

### DIFF
--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -263,3 +263,7 @@
 
 /atom/movable/screen/fullscreen/dreaming/waking_up
 	icon_state = "wake_up"
+
+/atom/movable/screen/fullscreen/psydon
+	icon = 'icons/mob/screen_full.dmi'
+	icon_state = "psydon"

--- a/code/datums/gods/faiths/old_god.dm
+++ b/code/datums/gods/faiths/old_god.dm
@@ -2,10 +2,10 @@
 	name = "Old God"
 	desc = "The Ifreet have spun a wool over the eyes of the Many, but we remember the Martyr well.\n\
 		<b>PSYDON YET LIVES. PSYDON BE SAVED.</b>\n\
-		Psydon of Jeruua once drowned beneath the river of Iron. What does it matter that he has died yet again?\
-		His Embers live on in all those who Remember him. The Sacred Flame shall never extinguish, and the Astral Teachings are eternal.\
-		Who cares for what the djinnist Tennites say? Their tongues speak only in lies, and it falls upon us to Persevere in the Truth.\
-		<b>The Apostates will burn in the Brimstone Gaol!</b>\
-		<b>A slow deat the inhumen! A slow death to those who doubt him!</b>"
+		Psydon of Jeruua once drowned beneath the river of Iron. What does it matter that he has died yet again? \
+		His Embers live on in all those who Remember him. The Sacred Flame shall never extinguish, and the Astral Teachings are eternal. \
+		Who cares for what the djinnist Tennites say? Their tongues speak only in lies, and it falls upon us to Persevere in the Truth. \
+		<b>The Apostates will burn in the Brimstone Gaol!</b>\n\
+		<b>A slow deat the inhumen! A slow death to those who doubt him!</b>\n"
 	worshippers = "People of Naledi, People of Giza, People of Hammerhold, People of Avar, Otavan Dark elves Orthodoxists, religious extremists."
 	godhead = /datum/patron/old_god

--- a/code/datums/gods/faiths/old_god.dm
+++ b/code/datums/gods/faiths/old_god.dm
@@ -1,8 +1,11 @@
 /datum/faith/old_god
 	name = "Old God"
-	desc = "The Holy See has been taken over by misguided fools who defile Psydon and worship false gods, but we survive.\n\
-		<b>PSYDON YET LIVES. PSYDON YET ENDURES.</b>\n\
-		PSYDON sent the COMET SYON to destroy the rampaging Godhena and save all Mortals. Though he remains silent now, the fools believe him DEAD - but \
-		PSYDON YET LIVES, AND PSYDON YET ENDURES. Unanswered prayers and impotent miracles - they are TESTS."
+	desc = "The Ifreet have spun a wool over the eyes of the Many, but we remember the Martyr well.\n\
+		<b>PSYDON YET LIVES. PSYDON BE SAVED.</b>\n\
+		Psydon of Jeruua once drowned beneath the river of Iron. What does it matter that he has died yet again?\
+		His Embers live on in all those who Remember him. The Sacred Flame shall never extinguish, and the Astral Teachings are eternal.\
+		Who cares for what the djinnist Tennites say? Their tongues speak only in lies, and it falls upon us to Persevere in the Truth.\
+		<b>The Apostates will burn in the Brimstone Gaol!</b>\
+		<b>A slow deat the inhumen! A slow death to those who doubt him!</b>"
 	worshippers = "People of Naledi, People of Giza, People of Hammerhold, People of Avar, Otavan Dark elves Orthodoxists, religious extremists."
 	godhead = /datum/patron/old_god

--- a/code/datums/gods/patrons/old_god.dm
+++ b/code/datums/gods/patrons/old_god.dm
@@ -1,14 +1,18 @@
 /datum/patron/old_god
 	name = "Psydon"
-	domain = "God of Ontological Reality"
-	desc = "The true God of everything, Psydon is maximally good - He created humen in his image to live in Psydonia, and defended the Black Basin by sending the COMET SYON to defeat the rampaging archdemon."
-	worshippers = "Fanatics and Nostalgists"
+	domain = "Celestial King of The Sacred Flame and Astral Majiyk"
+	desc = "The Holy Martyr once cast into the River of Iron, thought dead by the astray believers of the Ten. His sacred embers live in all those who Remember him. A God cannot ever truly die, and Psydon is no exception. Those whose faith remains firm in the Martyr scoff at the Djinni lie of the Ten, and eagerly plot to send all the Apostates to the Great Silence"
+	worshippers = "Fanatics and Nostalgists, and those of the Holier Lands"
 	associated_faith = /datum/faith/old_god
 	miracles = list(/obj/effect/proc_holder/spell/targeted/touch/orison			= CLERIC_ORI,
 					/obj/effect/proc_holder/spell/invoked/lesser_heal 			= CLERIC_T0,
+					/obj/effect/proc_holder/spell/targeted/churn 			= CLERIC_T1,
+					/obj/effect/proc_holder/spell/self/divine_strike			= CLERIC_T2,
+					/obj/effect/proc_holder/spell/invoked/revive				= CLERIC_T3,
 	)
 	confess_lines = list(
 		"THERE IS ONLY ONE TRUE GOD!",
 		"PSYDON YET LIVES! PSYDON YET ENDURES!",
 		"REBUKE THE HERETICAL- PSYDON ENDURES!",
+		"PSYDON BE SAVED!"
 	)

--- a/code/datums/gods/patrons/old_god.dm
+++ b/code/datums/gods/patrons/old_god.dm
@@ -7,7 +7,7 @@
 	miracles = list(/obj/effect/proc_holder/spell/targeted/touch/orison			= CLERIC_ORI,
 					/obj/effect/proc_holder/spell/invoked/lesser_heal 			= CLERIC_T0,
 					/obj/effect/proc_holder/spell/targeted/churn 			= CLERIC_T1,
-					/obj/effect/proc_holder/spell/self/divine_strike			= CLERIC_T2,
+					/obj/effect/proc_holder/spell/invoked/elucidate			= CLERIC_T2,
 					/obj/effect/proc_holder/spell/invoked/revive				= CLERIC_T3,
 	)
 	confess_lines = list(

--- a/code/datums/gods/patrons/old_god.dm
+++ b/code/datums/gods/patrons/old_god.dm
@@ -6,8 +6,8 @@
 	associated_faith = /datum/faith/old_god
 	miracles = list(/obj/effect/proc_holder/spell/targeted/touch/orison			= CLERIC_ORI,
 					/obj/effect/proc_holder/spell/invoked/lesser_heal 			= CLERIC_T0,
-					/obj/effect/proc_holder/spell/targeted/churn 			= CLERIC_T1,
-					/obj/effect/proc_holder/spell/invoked/elucidate			= CLERIC_T2,
+					/obj/effect/proc_holder/spell/invoked/elucidate			= CLERIC_T1,
+					/obj/effect/proc_holder/spell/targeted/churn 			= CLERIC_T2,
 					/obj/effect/proc_holder/spell/invoked/revive				= CLERIC_T3,
 	)
 	confess_lines = list(

--- a/code/datums/stress/positive_events.dm
+++ b/code/datums/stress/positive_events.dm
@@ -221,3 +221,8 @@
 	stressadd = -1
 	desc = span_green("I have prevailed over my rival! Graggar favours me now!")
 	timer = INFINITY
+
+/datum/stressevent/psicross_worn
+	stressadd = -2
+	desc = span_green("PSYDON protects me.")
+	timer = INFINITY

--- a/code/modules/clothing/rogueclothes/neck.dm
+++ b/code/modules/clothing/rogueclothes/neck.dm
@@ -269,14 +269,14 @@
 	grid_width = 32
 	grid_height = 32
 
-/obj/item/clothing/neck/roguetown/psicross/equipped(mob/user, slot) //Psydonians now get warm fuzzies when they equip their psycross.
+/obj/item/clothing/neck/roguetown/psicross/equipped(mob/living/carbon/human/user, slot) //Psydonians now get warm fuzzies when they equip their psycross.
 	. = ..()
 	if(user.patron == /datum/patron/old_god)
 		user.add_stress(/datum/stressevent/psicross_worn)
 		ADD_TRAIT(user, TRAIT_ANTIMAGIC, MAGIC_TRAIT)
 		ADD_TRAIT(user,TRAIT_ZOMBIE_IMMUNE, MAGIC_TRAIT)
 
-/obj/item/clothing/neck/roguetown/psicross/dropped(mob/user)
+/obj/item/clothing/neck/roguetown/psicross/dropped(mob/living/carbon/human/user)
 	. = ..()
 	if(user.patron == /datum/patron/old_god)
 		user.remove_stress(/datum/stressevent/psicross_worn)

--- a/code/modules/clothing/rogueclothes/neck.dm
+++ b/code/modules/clothing/rogueclothes/neck.dm
@@ -271,7 +271,7 @@
 
 /obj/item/clothing/neck/roguetown/psicross/equipped(mob/living/carbon/human/user, slot) //Psydonians now get warm fuzzies when they equip their psycross.
 	. = ..()
-	if(slot == ITEM_SLOT_NECK || slot == ITEM_SLOT_WRISTS || slot == ITEM_SLOT_HIP)
+	if(slot == SLOT_NECK || slot == SLOT_WRISTS || slot == SLOT_BELT_R || slot == SLOT_BELT_L)
 		if(istype(user.patron, /datum/patron/old_god))
 			user.add_stress(/datum/stressevent/psicross_worn)
 			ADD_TRAIT(user, TRAIT_ANTIMAGIC, MAGIC_TRAIT)

--- a/code/modules/clothing/rogueclothes/neck.dm
+++ b/code/modules/clothing/rogueclothes/neck.dm
@@ -271,7 +271,7 @@
 
 /obj/item/clothing/neck/roguetown/psicross/equipped(mob/living/carbon/human/user, slot) //Psydonians now get warm fuzzies when they equip their psycross.
 	. = ..()
-	if(slot == SLOT_NECK || slot == SLOT_WRISTS)
+	if(slot == ITEM_SLOT_NECK || slot == ITEM_SLOT_WRISTS || slot == ITEM_SLOT_HIP)
 		if(istype(user.patron, /datum/patron/old_god))
 			user.add_stress(/datum/stressevent/psicross_worn)
 			ADD_TRAIT(user, TRAIT_ANTIMAGIC, MAGIC_TRAIT)

--- a/code/modules/clothing/rogueclothes/neck.dm
+++ b/code/modules/clothing/rogueclothes/neck.dm
@@ -271,10 +271,12 @@
 
 /obj/item/clothing/neck/roguetown/psicross/equipped(mob/living/carbon/human/user, slot) //Psydonians now get warm fuzzies when they equip their psycross.
 	. = ..()
-	if(istype(user.patron, /datum/patron/old_god))
-		user.add_stress(/datum/stressevent/psicross_worn)
-		ADD_TRAIT(user, TRAIT_ANTIMAGIC, MAGIC_TRAIT)
-		ADD_TRAIT(user,TRAIT_ZOMBIE_IMMUNE, MAGIC_TRAIT)
+	if(slot == SLOT_NECK || slot == SLOT_WRISTS)
+		if(istype(user.patron, /datum/patron/old_god))
+			user.add_stress(/datum/stressevent/psicross_worn)
+			ADD_TRAIT(user, TRAIT_ANTIMAGIC, MAGIC_TRAIT)
+			ADD_TRAIT(user, TRAIT_ZOMBIE_IMMUNE, MAGIC_TRAIT)
+
 
 /obj/item/clothing/neck/roguetown/psicross/dropped(mob/living/carbon/human/user)
 	. = ..()

--- a/code/modules/clothing/rogueclothes/neck.dm
+++ b/code/modules/clothing/rogueclothes/neck.dm
@@ -269,6 +269,21 @@
 	grid_width = 32
 	grid_height = 32
 
+/obj/item/clothing/neck/roguetown/psicross/equipped(mob/user, slot) //Psydonians now get warm fuzzies when they equip their psycross.
+	. = ..()
+	if(user.patron == /datum/patron/old_god)
+		user.add_stress(/datum/stressevent/psicross_worn)
+		ADD_TRAIT(user, TRAIT_ANTIMAGIC, MAGIC_TRAIT)
+		ADD_TRAIT(user,TRAIT_ZOMBIE_IMMUNE, MAGIC_TRAIT)
+
+/obj/item/clothing/neck/roguetown/psicross/dropped(mob/user)
+	. = ..()
+	if(user.patron == /datum/patron/old_god)
+		user.remove_stress(/datum/stressevent/psicross_worn)
+		REMOVE_TRAIT(user, TRAIT_ANTIMAGIC, MAGIC_TRAIT)
+		REMOVE_TRAIT(user,TRAIT_ZOMBIE_IMMUNE, MAGIC_TRAIT)
+	
+
 /obj/item/clothing/neck/roguetown/psicross/mob_can_equip(mob/living/M, mob/living/equipper, slot, disable_warning = FALSE, bypass_equip_delay_self = FALSE)
 	..()
 

--- a/code/modules/clothing/rogueclothes/neck.dm
+++ b/code/modules/clothing/rogueclothes/neck.dm
@@ -271,14 +271,14 @@
 
 /obj/item/clothing/neck/roguetown/psicross/equipped(mob/living/carbon/human/user, slot) //Psydonians now get warm fuzzies when they equip their psycross.
 	. = ..()
-	if(user.patron == /datum/patron/old_god)
+	if(istype(user.patron, /datum/patron/old_god))
 		user.add_stress(/datum/stressevent/psicross_worn)
 		ADD_TRAIT(user, TRAIT_ANTIMAGIC, MAGIC_TRAIT)
 		ADD_TRAIT(user,TRAIT_ZOMBIE_IMMUNE, MAGIC_TRAIT)
 
 /obj/item/clothing/neck/roguetown/psicross/dropped(mob/living/carbon/human/user)
 	. = ..()
-	if(user.patron == /datum/patron/old_god)
+	if(istype(user.patron, /datum/patron/old_god))
 		user.remove_stress(/datum/stressevent/psicross_worn)
 		REMOVE_TRAIT(user, TRAIT_ANTIMAGIC, MAGIC_TRAIT)
 		REMOVE_TRAIT(user,TRAIT_ZOMBIE_IMMUNE, MAGIC_TRAIT)

--- a/code/modules/spells/roguetown/acolyte/necra.dm
+++ b/code/modules/spells/roguetown/acolyte/necra.dm
@@ -71,15 +71,9 @@
 				user.throw_at(get_ranged_target_turf(user, get_dir(user,L), 7), 7, 1, L, spin = FALSE)
 				return
 		if((L.mob_biotypes & MOB_UNDEAD) || isvampire || iszombie)
-			var/vamp_prob = prob2explode
-			if(isvampire)
-				vamp_prob -= 59
-			if(prob(vamp_prob))
-				L.visible_message("<span class='warning'>[L] has been churned by Necra's grip!", "<span class='danger'>I've been churned by Necra's grip!")
-				explosion(get_turf(L), light_impact_range = 1, flame_range = 1, smoke = FALSE)
-				L.Stun(50)
-			else
-				L.visible_message(span_warning("[L] resists being churned!"), span_userdanger("I resist being churned!"))
+			L.visible_message("<span class='warning'>[L] has been churned!", "<span class='danger'>I've been churned!")
+			explosion(get_turf(L), light_impact_range = 1, flame_range = 1, smoke = FALSE)
+			L.Stun(50)
 	..()
 	return TRUE
 

--- a/code/modules/spells/roguetown/acolyte/psydon.dm
+++ b/code/modules/spells/roguetown/acolyte/psydon.dm
@@ -41,7 +41,7 @@
 
 /datum/status_effect/elucidated
 	id = "elucidated"
-	alert_type = 
+	alert_type = /atom/movable/screen/alert/status_effect/elucidated
 	status_type = STATUS_EFFECT_UNIQUE
 	duration = 30 SECONDS
 	alert_type = /atom/movable/screen/alert/status_effect/elucidated

--- a/code/modules/spells/roguetown/acolyte/psydon.dm
+++ b/code/modules/spells/roguetown/acolyte/psydon.dm
@@ -2,6 +2,7 @@
 
 /obj/effect/proc_holder/spell/invoked/elucidate
 	name = "Elucidate"
+	overlay_state = "limb_attach"
 	desc = "The Agonizing Truth of the Martyr causes a temporary seizure of the senses."
 	recharge_time = 10 SECONDS
 	chargetime = 0 SECONDS

--- a/code/modules/spells/roguetown/acolyte/psydon.dm
+++ b/code/modules/spells/roguetown/acolyte/psydon.dm
@@ -7,28 +7,30 @@
 	chargetime = 0 SECONDS
 	chargedrain = 0 SECONDS
 	movement_interrupt = FALSE
+	warnie = "sydwarning"
 	associated_skill = /datum/skill/magic/holy
 	req_items = list(/obj/item/clothing/neck/roguetown/psicross)
 	sound = 'sound/magic/antimagic.ogg'
 	invocation = "PSYDON! UNVEIL THE TRUTH!"
 	invocation_type = "shout"
-	miracle = TRUE
 	antimagic_allowed = TRUE
+	miracle = TRUE
 	devotion_cost = 10
 
 /obj/effect/proc_holder/spell/invoked/elucidate/cast(list/targets, mob/user = usr)
-	var/list/sounds = list(
+	. = ..()
+	if(isliving(targets[1]))
+		var/mob/living/target = targets[1]
+		if(istype(target.patron, /datum/patron/old_god)) //We don't target our brothers
+			return FALSE
+		target.visible_message(span_warning("[user] elucidates [target]!"),span_warning("I HAVE BEEN ILLUMINATED!"))
+		target.apply_status_effect(/datum/status_effect/elucidated)
+		var/list/sounds = list(
 		'sound/villain/hall_attack1.ogg',
 		'sound/villain/hall_attack2.ogg',
 		'sound/villain/hall_attack3.ogg',
 		'sound/villain/hall_attack4.ogg',
-	)
-	if(isliving(targets[1]))
-		var/mob/living/target = targets[1]
-		if(target.patron != /datum/patron/old_god) //We don't target our brothers
-			return FALSE
-		target.visible_message(span_warning("[user] elucidates [target]!"),span_warning("I HAVE BEEN ILLUMINATED!"))
-		target.apply_status_effect(/datum/status_effect/elucidated)
+		)
 		target.playsound_local(target, pick(sounds), vol = 100, vary = FALSE)
 		if(alert(target, "Do you accept the Truth of PSYDON?", "JUDGEMENT", "Yes", "No") == "Yes")
 			target.set_patron(/datum/patron/old_god)

--- a/code/modules/spells/roguetown/acolyte/psydon.dm
+++ b/code/modules/spells/roguetown/acolyte/psydon.dm
@@ -3,10 +3,10 @@
 /obj/effect/proc_holder/spell/invoked/elucidate
 	name = "Elucidate"
 	desc = "The Agonizing Truth of the Martyr causes a temporary seizure of the senses."
-	recharge_time = 15 SECONDS
+	recharge_time = 10 SECONDS
+	chargetime = 0 SECONDS
+	chargedrain = 0 SECONDS
 	movement_interrupt = FALSE
-	chargedrain = 0
-	chargetime = 5 SECONDS
 	associated_skill = /datum/skill/magic/holy
 	req_items = list(/obj/item/clothing/neck/roguetown/psicross)
 	sound = 'sound/magic/antimagic.ogg'
@@ -30,6 +30,7 @@
 		if(target.patron != /datum/patron/old_god) //We don't target our brothers
 			return FALSE
 		target.visible_message(span_warning("[user] elucidates [target]!"),span_warning("I HAVE BEEN ILLUMINATED!"))
+		target.apply_status_effect(/datum/status_effect/elucidated)
 		target.playsound_local(target, pick(sounds), vol = 100, vary = FALSE)
 		if(alert(target, "Do you accept the Truth of PSYDON?", "JUDGEMENT", "Yes", "No") == "Yes")
 			target.patron = /datum/patron/old_god
@@ -44,7 +45,6 @@
 	alert_type = /atom/movable/screen/alert/status_effect/elucidated
 	status_type = STATUS_EFFECT_UNIQUE
 	duration = 30 SECONDS
-	alert_type = /atom/movable/screen/alert/status_effect/elucidated
 
 /datum/status_effect/elucidated/on_apply()
 	owner.overlay_fullscreen("elucidated", /atom/movable/screen/fullscreen/psydon)

--- a/code/modules/spells/roguetown/acolyte/psydon.dm
+++ b/code/modules/spells/roguetown/acolyte/psydon.dm
@@ -31,7 +31,7 @@
 		target.apply_status_effect(/datum/status_effect/elucidated)
 		target.playsound_local(target, pick(sounds), vol = 100, vary = FALSE)
 		if(alert(target, "Do you accept the Truth of PSYDON?", "JUDGEMENT", "Yes", "No") == "Yes")
-			target.patron = /datum/patron/old_god
+			target.set_patron(/datum/patron/old_god)
 		return TRUE
 	revert_cast()
 	return FALSE

--- a/code/modules/spells/roguetown/acolyte/psydon.dm
+++ b/code/modules/spells/roguetown/acolyte/psydon.dm
@@ -44,7 +44,7 @@
 	id = "elucidated"
 	alert_type = /atom/movable/screen/alert/status_effect/elucidated
 	status_type = STATUS_EFFECT_UNIQUE
-	duration = 30 SECONDS
+	duration = 15 SECONDS
 
 /datum/status_effect/elucidated/on_apply()
 	owner.overlay_fullscreen("elucidated", /atom/movable/screen/fullscreen/psydon)

--- a/code/modules/spells/roguetown/acolyte/psydon.dm
+++ b/code/modules/spells/roguetown/acolyte/psydon.dm
@@ -1,6 +1,6 @@
 // PSY'S TRUTH IS BLINDING
 
-/obj/effect/proc_holder/spell/self/divine_strike
+/obj/effect/proc_holder/spell/invoked/elucidate
 	name = "Elucidate"
 	desc = "The Agonizing Truth of the Martyr causes a temporary seizure of the senses."
 	recharge_time = 15 SECONDS

--- a/code/modules/spells/roguetown/acolyte/psydon.dm
+++ b/code/modules/spells/roguetown/acolyte/psydon.dm
@@ -25,8 +25,6 @@
 	)
 	if(isliving(targets[1]))
 		var/mob/living/target = targets[1]
-		if(target.anti_magic_check(TRUE, TRUE))
-			return FALSE
 		if(target.patron != /datum/patron/old_god) //We don't target our brothers
 			return FALSE
 		target.visible_message(span_warning("[user] elucidates [target]!"),span_warning("I HAVE BEEN ILLUMINATED!"))

--- a/code/modules/spells/roguetown/acolyte/psydon.dm
+++ b/code/modules/spells/roguetown/acolyte/psydon.dm
@@ -1,0 +1,59 @@
+// PSY'S TRUTH IS BLINDING
+
+/obj/effect/proc_holder/spell/self/divine_strike
+	name = "Elucidate"
+	desc = "The Agonizing Truth of the Martyr causes a temporary seizure of the senses."
+	recharge_time = 15 SECONDS
+	movement_interrupt = FALSE
+	chargedrain = 0
+	chargetime = 5 SECONDS
+	associated_skill = /datum/skill/magic/holy
+	req_items = list(/obj/item/clothing/neck/roguetown/psicross)
+	sound = 'sound/magic/antimagic.ogg'
+	invocation = "PSYDON! UNVEIL THE TRUTH!"
+	invocation_type = "shout"
+	miracle = TRUE
+	antimagic_allowed = TRUE
+	devotion_cost = 10
+
+/obj/effect/proc_holder/spell/invoked/elucidate/cast(list/targets, mob/user = usr)
+	var/list/sounds = list(
+		'sound/villain/hall_attack1.ogg',
+		'sound/villain/hall_attack2.ogg',
+		'sound/villain/hall_attack3.ogg',
+		'sound/villain/hall_attack4.ogg',
+	)
+	if(isliving(targets[1]))
+		var/mob/living/target = targets[1]
+		if(target.anti_magic_check(TRUE, TRUE))
+			return FALSE
+		if(target.patron != /datum/patron/old_god) //We don't target our brothers
+			return FALSE
+		target.visible_message(span_warning("[user] elucidates [target]!"),span_warning("I HAVE BEEN ILLUMINATED!"))
+		target.playsound_local(target, pick(sounds), vol = 100, vary = FALSE)
+		if(alert(target, "Do you accept the Truth of PSYDON?", "JUDGEMENT", "Yes", "No") == "Yes")
+			target.patron = /datum/patron/old_god
+		return TRUE
+	revert_cast()
+	return FALSE
+
+
+
+/datum/status_effect/elucidated
+	id = "elucidated"
+	alert_type = 
+	status_type = STATUS_EFFECT_UNIQUE
+	duration = 30 SECONDS
+	alert_type = /atom/movable/screen/alert/status_effect/elucidated
+
+/datum/status_effect/elucidated/on_apply()
+	owner.overlay_fullscreen("elucidated", /atom/movable/screen/fullscreen/psydon)
+
+/datum/status_effect/elucidated/on_remove()
+	owner.clear_fullscreen("elucidated")
+
+
+/atom/movable/screen/alert/status_effect/elucidated
+	name = "TRUTH"
+	desc = "No... IT CAN'T BE!"
+	icon_state = "stressvb"

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -2033,6 +2033,7 @@
 #include "code\modules\spells\roguetown\acolyte\necra.dm"
 #include "code\modules\spells\roguetown\acolyte\noc.dm"
 #include "code\modules\spells\roguetown\acolyte\pestra.dm"
+#include "code\modules\spells\roguetown\acolyte\psydon.dm"
 #include "code\modules\spells\roguetown\acolyte\ravox.dm"
 #include "code\modules\spells\roguetown\acolyte\xylix.dm"
 #include "code\modules\spells\roguetown\acolyte\eora\eora_reagents.dm"


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

I've been told by certain Psydonites that the old faith's been missing a lot of flavour and features in the time since the heyday of the ChatGPT'd Ten. To rectify that I've given them a few features:

- A Unique Conversion T1 Miracle
- T1-T3 miracles reminiscent of their classic Roguetown incarnations
- A mood buff and protection from curses if they dare to don the heretical psycross in public

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->
![image](https://github.com/user-attachments/assets/bbbb40e8-5add-4347-8b96-26d2e60e2c9f)
![image](https://github.com/user-attachments/assets/ac5f2298-62aa-4f31-ab60-d2598116bc11)
![image](https://github.com/user-attachments/assets/4ff8651f-35ca-4b37-92a0-a82811701553)

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

From an OOC perspective, now that Psydonism is heretical, it's probably a good idea to give people a reason to play the proscribed Psydonians. I also wanted to experiment with giving them a spell list reminiscent of the pre-Raytown days where the main benefit to being a Psydonian came from the passive benefits of being one - such as worn psicrosses offering you protection from those kinds of evils ontologically opposite of the light. 

Overall, I think I've done a decent job of finally giving Psydonism a proper niche within the scheme of (modern) heterodoxy. 