### PR TITLE
Pinning no longer has a passive stamina cost

### DIFF
--- a/code/modules/mob/living/grabbing.dm
+++ b/code/modules/mob/living/grabbing.dm
@@ -284,13 +284,11 @@
 							break
 						M.Stun(stun_dur - pincount * 2)	
 						M.Immobilize(stun_dur)	//Made immobile for the whole do_after duration, though
-						user.rogfat_add(rand(1,3) + abs(skill_diff) + stun_dur / 1.5)
 						M.visible_message(span_danger("[user] keeps [M] pinned to the ground!"))
 						pincount += 2
 					else if(src in M.grabbedby)
 						M.Stun(stun_dur - 10)
 						M.Immobilize(stun_dur)
-						user.rogfat_add(rand(1,3) + abs(skill_diff) + stun_dur / 1.5)
 						pincount += 2
 						M.visible_message(span_danger("[user] pins [M] to the ground!"), \
 							span_userdanger("[user] pins me to the ground!"), span_hear("I hear a sickening sound of pugilism!"), COMBAT_MESSAGE_RANGE)


### PR DESCRIPTION
## About The Pull Request
Title. Keeping someone actively pinned does not cost stamina. 
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Tested it in local host. Worked as described.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Pinning is currently effectively useless. The only use case where it may be useful is if you are 1 person with a gaggle of goons trying to beat 1 other person. As in, it is only useful if you already have an insanely huge advantage. No no.
This is still the case, however now it is usable in 1v1s. This means if you're the better wrassler you can fuck up your opponent by wrassling them and pinning without constantly running out of stamina. Keep in mind, your opponent still gets an opportunity to resist you every time you reset the pin cooldown, and THAT drains your stamina.
The main boon from this is that, in a 1v1, I can now actually force my opponent to RP with me if I pin them to the ground. This can be used for all kinds of magical things. Hooray!
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
