### PR TITLE
Better butchering + leatherworking for poacher wretch

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/poacher.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/poacher.dm
@@ -39,9 +39,9 @@
 	H.mind.adjust_skillrank(/datum/skill/craft/traps, 4, TRUE)
 	//these people live in the forest so let's give them some peasant skills
 	H.mind.adjust_skillrank(/datum/skill/craft/crafting, 1, TRUE)
-	H.mind.adjust_skillrank(/datum/skill/craft/tanning, 1, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/craft/tanning, 3, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/craft/cooking, 1, TRUE)
-	H.mind.adjust_skillrank(/datum/skill/labor/butchering, 1, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/labor/butchering, 3, TRUE)
 	H.cmode_music = 'sound/music/combat_poacher.ogg'
 	var/weapons = list("Dagger","Axe", "Cudgel", "My Bow Is Enough")
 	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons


### PR DESCRIPTION
## About The Pull Request
Butchering skill increased from 1 to 3.
Tanning (leatherworking) skill increased from 1 to 3.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Tested it in my mind. Seems to work.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
The poacher wretch is supposed to be a huntsman that got in trouble for hunting too much. It seems weird that they only get 1 skill level of both butchering and leather working. Having only 1 skill level of butchering means a lot of animals that the poacher butchers are ruined and therefore drop no fur/hide. I think it doesn't make sense storywise for the /poacher/ to be bad at skinning the animals he hunts.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
