### PR TITLE
Buff acryne potential - Host Approved

### DIFF
--- a/code/modules/spells/spell_types/wizard/buffs_debuffs/enlarge.dm
+++ b/code/modules/spells/spell_types/wizard/buffs_debuffs/enlarge.dm
@@ -10,7 +10,7 @@
 	no_early_release = TRUE
 	movement_interrupt = FALSE
 	charging_slowdown = 3
-	spell_tier = 2
+	spell_tier = 1
 	invocation = "Dilatare!"
 	invocation_type = "shout"
 	chargedloop = /datum/looping_sound/wind

--- a/code/modules/spells/spell_types/wizard/buffs_debuffs/fortitude.dm
+++ b/code/modules/spells/spell_types/wizard/buffs_debuffs/fortitude.dm
@@ -12,7 +12,7 @@
 	overlay_state = "fortitude"
 	no_early_release = TRUE
 	movement_interrupt = FALSE
-	spell_tier = 2
+	spell_tier = 1
 	invocation = "Tenax"
 	invocation_type = "whisper"
 	glow_color = GLOW_COLOR_BUFF

--- a/code/modules/spells/spell_types/wizard/buffs_debuffs/giants_strength.dm
+++ b/code/modules/spells/spell_types/wizard/buffs_debuffs/giants_strength.dm
@@ -11,7 +11,7 @@
 	warnie = "spellwarning"
 	school = "transmutation"
 	overlay_state = "giants_strength"
-	spell_tier = 2
+	spell_tier = 1
 	invocation = "Vis Gigantis." // Vis - Strength. Gigantis - Singular possessive form.
 	invocation_type = "whisper"
 	glow_color = GLOW_COLOR_BUFF

--- a/code/modules/spells/spell_types/wizard/buffs_debuffs/giants_strength.dm
+++ b/code/modules/spells/spell_types/wizard/buffs_debuffs/giants_strength.dm
@@ -11,7 +11,7 @@
 	warnie = "spellwarning"
 	school = "transmutation"
 	overlay_state = "giants_strength"
-	spell_tier = 1
+	spell_tier = 2
 	invocation = "Vis Gigantis." // Vis - Strength. Gigantis - Singular possessive form.
 	invocation_type = "whisper"
 	glow_color = GLOW_COLOR_BUFF

--- a/code/modules/spells/spell_types/wizard/buffs_debuffs/guidance.dm
+++ b/code/modules/spells/spell_types/wizard/buffs_debuffs/guidance.dm
@@ -10,7 +10,7 @@
 	recharge_time = 2 MINUTES
 	warnie = "spellwarning"
 	school = "transmutation"
-	spell_tier = 2
+	spell_tier = 1
 	invocation = "Ducere"
 	invocation_type = "whisper"
 	glow_color = GLOW_COLOR_BUFF

--- a/code/modules/spells/spell_types/wizard/buffs_debuffs/haste.dm
+++ b/code/modules/spells/spell_types/wizard/buffs_debuffs/haste.dm
@@ -10,7 +10,7 @@
 	warnie = "spellwarning"
 	school = "transmutation"
 	overlay_state = "rune3" // Temporary
-	spell_tier = 2
+	spell_tier = 1
 	invocation = "Festinatio!"
 	invocation_type = "shout" // I mean, it is fast
 	glow_color = GLOW_COLOR_BUFF

--- a/code/modules/spells/spell_types/wizard/buffs_debuffs/hawks_eyes.dm
+++ b/code/modules/spells/spell_types/wizard/buffs_debuffs/hawks_eyes.dm
@@ -10,7 +10,7 @@
 	recharge_time = 2 MINUTES
 	warnie = "spellwarning"
 	school = "transmutation"
-	spell_tier = 2
+	spell_tier = 1
 	invocation = "Oculi Accipitris." // Oculi - Eyes. Accipitris - Hawk, singular.
 	invocation_type = "whisper"
 	glow_color = GLOW_COLOR_BUFF

--- a/code/modules/spells/spell_types/wizard/buffs_debuffs/leap.dm
+++ b/code/modules/spells/spell_types/wizard/buffs_debuffs/leap.dm
@@ -10,7 +10,7 @@
 	no_early_release = TRUE
 	movement_interrupt = FALSE
 	gesture_required = TRUE // Mobility spell
-	spell_tier = 2
+	spell_tier = 1
 	invocation = "Saltus!"
 	invocation_type = "whisper"
 	hide_charge_effect = TRUE

--- a/code/modules/spells/spell_types/wizard/buffs_debuffs/stoneskin.dm
+++ b/code/modules/spells/spell_types/wizard/buffs_debuffs/stoneskin.dm
@@ -11,7 +11,7 @@
 	recharge_time = 2 MINUTES
 	warnie = "spellwarning"
 	school = "transmutation"
-	spell_tier = 2
+	spell_tier = 1
 	invocation = "Perstare Sicut Saxum." // Endure like Stone 
 	invocation_type = "whisper"
 	glow_color = GLOW_COLOR_BUFF

--- a/code/modules/spells/spell_types/wizard/misc/enchant_weapon.dm
+++ b/code/modules/spells/spell_types/wizard/misc/enchant_weapon.dm
@@ -26,7 +26,7 @@
 
 	charging_slowdown = 3
 	cost = 2 // Slightly discounted as it is mostly buff.
-	spell_tier = 2 // Spellblade tier.
+	spell_tier = 1
 
 	invocation = "Incantare Arma!" // Enchant Weapon(s)
 	invocation_type = "whisper"

--- a/code/modules/spells/spell_types/wizard/projectiles_single/fetch.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_single/fetch.dm
@@ -13,7 +13,7 @@
 	overlay_state = "fetch"
 	no_early_release = TRUE
 	charging_slowdown = 1
-	spell_tier = 2
+	spell_tier = 1
 	invocation = "Recolligere"
 	invocation_type = "whisper"
 	hide_charge_effect = TRUE // essential for rogue mage

--- a/code/modules/spells/spell_types/wizard/projectiles_single/repel.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_single/repel.dm
@@ -17,7 +17,7 @@
 	charging_slowdown = 1
 	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/arcane
-	spell_tier = 2
+	spell_tier = 1
 	invocation = "Exmoveo!"
 	invocation_type = "shout"
 	glow_color = GLOW_COLOR_DISPLACEMENT

--- a/modular_azurepeak/virtues/combat.dm
+++ b/modular_azurepeak/virtues/combat.dm
@@ -2,18 +2,19 @@
 /datum/virtue/combat/magical_potential
 	name = "Arcyne Potential"
 	desc = "I am talented in the Arcyne arts, expanding my capacity for magic. I have become more intelligent from its studies. Other effects depends on what training I chose to focus on at a later age."
-	custom_text = "Classes that has a combat trait (Medium / Heavy Armor Training, Dodge Expert or Critical Resistance) get only prestidigitation. Everyone else get +10 spellpoints and T2 Arcyne Potential if they don't have any Arcyne."
+	custom_text = "Classes that have a combat trait (Medium / Heavy Armor Training, Dodge Expert, Critical Resistance, Civilized Barbarian, or Battle Ready) get only prestidigitation. Everyone else gets +8 spellpoints and T2 Arcyne Potential if they don't have any Arcyne."
 	added_skills = list(list(/datum/skill/magic/arcane, 1, 6))
 
 /datum/virtue/combat/magical_potential/apply_to_human(mob/living/carbon/human/recipient)
 	if (!recipient.mind?.get_skill_level(/datum/skill/magic/arcane)) // we can do this because apply_to is always called first
 		if (!recipient.mind?.has_spell(/obj/effect/proc_holder/spell/targeted/touch/prestidigitation))
 			recipient.mind?.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
-		if (!HAS_TRAIT(recipient, TRAIT_MEDIUMARMOR) && !HAS_TRAIT(recipient, TRAIT_HEAVYARMOR) && !HAS_TRAIT(recipient, TRAIT_DODGEEXPERT) && !HAS_TRAIT(recipient, TRAIT_CRITICAL_RESISTANCE))
+		if (!HAS_TRAIT(recipient, TRAIT_MEDIUMARMOR) && !HAS_TRAIT(recipient, TRAIT_HEAVYARMOR) && !HAS_TRAIT(recipient, TRAIT_DODGEEXPERT) && !HAS_TRAIT(recipient, TRAIT_CRITICAL_RESISTANCE) && !HAS_TRAIT(recipient, TRAIT_CIVILIZEDBARBARIAN) && !HAS_TRAIT(recipient, TRAIT_BREADY))
 			ADD_TRAIT(recipient, TRAIT_ARCYNE_T2, TRAIT_GENERIC)
-			recipient.mind?.adjust_spellpoints(10)
+			ADD_TRAIT(recipient, TRAIT_MAGEARMOR, TRAIT_GENERIC)
+			recipient.mind?.adjust_spellpoints(8)
 	else
-		recipient.mind?.adjust_spellpoints(10) // 3 extra spellpoints since you don't get any spell point from the skill anymore
+		recipient.mind?.adjust_spellpoints(8) // 8 extra spellpoints since you don't get any spell point from the skill anymore
 	
 /datum/virtue/combat/devotee
 	name = "Devotee"

--- a/modular_azurepeak/virtues/combat.dm
+++ b/modular_azurepeak/virtues/combat.dm
@@ -2,15 +2,15 @@
 /datum/virtue/combat/magical_potential
 	name = "Arcyne Potential"
 	desc = "I am talented in the Arcyne arts, expanding my capacity for magic. I have become more intelligent from its studies. Other effects depends on what training I chose to focus on at a later age."
-	custom_text = "Classes that have a combat trait (Medium / Heavy Armor Training, Dodge Expert, Critical Resistance, Civilized Barbarian, or Battle Ready) get only prestidigitation. Everyone else gets +8 spellpoints and T2 Arcyne Potential if they don't have any Arcyne."
+	custom_text = "Classes that have a combat trait (Medium / Heavy Armor Training, Dodge Expert, Critical Resistance, Civilized Barbarian, Battle Ready, or Arcyne T2/T3) get only prestidigitation. Everyone else gets +8 spellpoints and T1 Arcyne Potential if they don't have any Arcyne."
 	added_skills = list(list(/datum/skill/magic/arcane, 1, 6))
 
 /datum/virtue/combat/magical_potential/apply_to_human(mob/living/carbon/human/recipient)
 	if (!recipient.mind?.get_skill_level(/datum/skill/magic/arcane)) // we can do this because apply_to is always called first
 		if (!recipient.mind?.has_spell(/obj/effect/proc_holder/spell/targeted/touch/prestidigitation))
 			recipient.mind?.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
-		if (!HAS_TRAIT(recipient, TRAIT_MEDIUMARMOR) && !HAS_TRAIT(recipient, TRAIT_HEAVYARMOR) && !HAS_TRAIT(recipient, TRAIT_DODGEEXPERT) && !HAS_TRAIT(recipient, TRAIT_CRITICAL_RESISTANCE) && !HAS_TRAIT(recipient, TRAIT_CIVILIZEDBARBARIAN) && !HAS_TRAIT(recipient, TRAIT_BREADY))
-			ADD_TRAIT(recipient, TRAIT_ARCYNE_T2, TRAIT_GENERIC)
+		if (!HAS_TRAIT(recipient, TRAIT_MEDIUMARMOR) && !HAS_TRAIT(recipient, TRAIT_HEAVYARMOR) && !HAS_TRAIT(recipient, TRAIT_DODGEEXPERT) && !HAS_TRAIT(recipient, TRAIT_CRITICAL_RESISTANCE) && !HAS_TRAIT(recipient, TRAIT_CIVILIZEDBARBARIAN) && !HAS_TRAIT(recipient, TRAIT_BREADY) && !HAS_TRAIT(recipient, TRAIT_ARCYNE_T2) && !HAS_TRAIT(recipient, TRAIT_ARCYNE_T3))
+			ADD_TRAIT(recipient, TRAIT_ARCYNE_T1, TRAIT_GENERIC)
 			ADD_TRAIT(recipient, TRAIT_MAGEARMOR, TRAIT_GENERIC)
 			recipient.mind?.adjust_spellpoints(8)
 	else

--- a/modular_azurepeak/virtues/combat.dm
+++ b/modular_azurepeak/virtues/combat.dm
@@ -14,7 +14,7 @@
 			ADD_TRAIT(recipient, TRAIT_MAGEARMOR, TRAIT_GENERIC)
 			recipient.mind?.adjust_spellpoints(8)
 	else
-		recipient.mind?.adjust_spellpoints(8) // 8 extra spellpoints since you don't get any spell point from the skill anymore
+		recipient.mind?.adjust_spellpoints(3) // 3 extra spellpoints since you don't get any spell point from the skill anymore
 	
 /datum/virtue/combat/devotee
 	name = "Devotee"

--- a/modular_azurepeak/virtues/combat.dm
+++ b/modular_azurepeak/virtues/combat.dm
@@ -2,7 +2,7 @@
 /datum/virtue/combat/magical_potential
 	name = "Arcyne Potential"
 	desc = "I am talented in the Arcyne arts, expanding my capacity for magic. I have become more intelligent from its studies. Other effects depends on what training I chose to focus on at a later age."
-	custom_text = "Classes that has a combat trait (Medium / Heavy Armor Training, Dodge Expert or Critical Resistance) get only prestidigitation. Everyone else get +3 spellpoints and T1 Arcyne Potential if they don't have any Arcyne."
+	custom_text = "Classes that has a combat trait (Medium / Heavy Armor Training, Dodge Expert or Critical Resistance) get only prestidigitation. Everyone else get +10 spellpoints and T2 Arcyne Potential if they don't have any Arcyne."
 	added_skills = list(list(/datum/skill/magic/arcane, 1, 6))
 
 /datum/virtue/combat/magical_potential/apply_to_human(mob/living/carbon/human/recipient)
@@ -10,10 +10,10 @@
 		if (!recipient.mind?.has_spell(/obj/effect/proc_holder/spell/targeted/touch/prestidigitation))
 			recipient.mind?.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
 		if (!HAS_TRAIT(recipient, TRAIT_MEDIUMARMOR) && !HAS_TRAIT(recipient, TRAIT_HEAVYARMOR) && !HAS_TRAIT(recipient, TRAIT_DODGEEXPERT) && !HAS_TRAIT(recipient, TRAIT_CRITICAL_RESISTANCE))
-			ADD_TRAIT(recipient, TRAIT_ARCYNE_T1, TRAIT_GENERIC)
-			recipient.mind?.adjust_spellpoints(3)
+			ADD_TRAIT(recipient, TRAIT_ARCYNE_T2, TRAIT_GENERIC)
+			recipient.mind?.adjust_spellpoints(10)
 	else
-		recipient.mind?.adjust_spellpoints(3) // 3 extra spellpoints since you don't get any spell point from the skill anymore
+		recipient.mind?.adjust_spellpoints(10) // 3 extra spellpoints since you don't get any spell point from the skill anymore
 	
 /datum/virtue/combat/devotee
 	name = "Devotee"


### PR DESCRIPTION
## About The Pull Request
Buffs acryne potential to be more usable.

The changes are:
acryne potential gives you:
T1 spell list
8+ spell points from 3+
Mage Armour
More restrictions to combat roles such as Cleric: Monks. Barbarians and the such by adding two more traits to the block list. Wizards can't get this anymore to have a insane amount of points.

Moved most of support spells to be from T2 to T1 as T1 does not have any combat spells and mostly support ones.

This should restrict more combat roles from accessing such. 
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Simple line changes
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
