### PR TITLE
silly scythe/militiapick nerf

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/polearms.dm
+++ b/code/game/objects/items/rogueweapons/melee/polearms.dm
@@ -44,7 +44,7 @@
 	damfactor = 0.9
 
 /datum/intent/spear/cut/scythe
-	reach = 3
+	reach = 2
 	damfactor = 1
 
 /datum/intent/spear/cut/bardiche

--- a/code/game/objects/items/rogueweapons/melee/special.dm
+++ b/code/game/objects/items/rogueweapons/melee/special.dm
@@ -569,7 +569,7 @@
 
 /obj/item/rogueweapon/scythe
 	force = 15
-	force_wielded = 25
+	force_wielded = 20
 	possible_item_intents = list(SPEAR_BASH)
 	gripped_intents = list(/datum/intent/spear/cut/scythe, SPEAR_BASH, MACE_STRIKE)
 	name = "scythe"
@@ -588,7 +588,7 @@
 	max_blade_int = 100
 	anvilrepair = /datum/skill/craft/carpentry
 	smeltresult = /obj/item/rogueore/coal
-	associated_skill = /datum/skill/labor/farming
+	associated_skill = /datum/skill/combat/polearms
 	blade_dulling = DULLING_SHAFT_WOOD
 	walking_stick = TRUE
 	wdefense = 6
@@ -625,7 +625,7 @@
 	max_blade_int = 80
 	max_integrity = 400
 	slot_flags = ITEM_SLOT_HIP
-	associated_skill = /datum/skill/labor/mining
+	associated_skill = /datum/skill/combat/axes
 	anvilrepair = /datum/skill/craft/carpentry
 	smeltresult = /obj/item/ingot/iron
 	wdefense = 1


### PR DESCRIPTION
## About The Pull Request

Did you know that miners and farmers could use mining/farming as a weaponskill, skills they(and ANYBODY that wants to!!) will VERY easily reach legendary in if they want to?
Did you know that the scythe has 3 reach, more than a real spear, despite being an incredibly awkward "polearm"?
No? You think that is ludicrous and surely that is not real, surely there is no towners with weaponskills much higher than knights?
Well you are wrong, both scythes and militiapicks had this mechanic, except for of course, steel militiapicks, for some reason.


This makes scythes use polearms, and picks use axes as skill. It also reduces the range on the scythe by 1.

## Testing Evidence

Numberchange.

## Why It's Good For The Game

It's an unfathomably silly, and makes no immersion sense. It belongs in some anime not reality, farming scythes are TERRIBLE weapons, and reaping grain does not AT ALL translate to real combat skill.. that is not how a scythe is used at all.
It's a terrible gameplay thing to exist, between farmers not being supposed to have legendary weaponskills and powergamers levelling farming/mining to absolutely style on people.
