### PR TITLE
Buffs the blacksteel flamberge

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -931,8 +931,8 @@
 /obj/item/rogueweapon/sword/long/blackflamb
 	name = "blacksteel flamberge"
 	desc = "An uncommon kind of sword with a characteristically undulating style of blade, made with an equally rare metal. The wave in the blade is considered to contribute a flame-like quality to its appearance, turning it into a menacing sight. \"Flaming swords\" are often the protagonists of Otavan epics and other knights' tales."
-	force = 20
-	force_wielded = 32
+	force = 29
+	force_wielded = 35
 	icon_state = "blackflamb"
 	smeltresult = /obj/item/ingot/blacksteel
 	max_integrity = 215


### PR DESCRIPTION


## About The Pull Request

the blacksteel flamberge is a rare/hard to make longsword(yes, not zwei) made from blacksteel and a ruby, and it is a skill 6 craft. Previously it had force 20 unwielded force 32 when wielded, this PR changes it to 29, 35 respectively.
A normal longsword has 25, 30. This means that previously, an unwielded blacksteel flamberge was much worse than a longsword and slightly better when wielded.
This buff makes it about 15% better in both situations.

The alternative I considered is making it inherit from the zwei, since its sprite already half-looks like a greatsword, and its relative stats (bad unwielded, good wielded) would make more sense there (though the wielded force would need to be buffed even higher, as currently it's equal with zwei).
This would mean it gets the better zwei intents (2tilestab).

## Testing Evidence

Yeah, I compiled this. and checked ingame. Though it's a one line numerical change.

## Why It's Good For The Game

I believe this rare weapon is cool, and people who pick it up assume it's better than a longsword, when it's really only a very slight bit better when wielded, and quite significantly worse when not.
Balance wise, swords are not all that broken and this rare one probably won't have real balance impact.
I still consider this sword worse than say a zwei(35 force aswell, but 2tile stab), or an estoc(less clickcd, 2tile attack, more pen), but these are dedicated greatswords.
Immersion wise, it is believable to me that a fantasy alloy is slightly (15%) better than steel, and we already have plenty of "slightly better weapons made with rare materials".
