### PR TITLE
slightly more distinct racial stats

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/furry/akula.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/akula.dm
@@ -12,7 +12,7 @@
 	seeing places many could not even dream of. They look down at those they considered the 'settled' \
 	and often uproot themselves quite often in their lifetimes. However, due to the isolation in Blackmoor, many Axians \
 	find their sanity being clawed away as they find themselves stuck in one place.<br>\
-	(+1 Constitution, +1 Endurance)"
+	(+1 Constitution, +2 Endurance, -1 Perception)"
 	species_traits = list(EYECOLOR,LIPS,STUBBLE,MUTCOLORS)
 	species_traits = list(EYECOLOR,LIPS,STUBBLE,MUTCOLORS)
 	inherent_traits = list(TRAIT_WATERBREATHING, TRAIT_SEA_DRINKER)
@@ -36,7 +36,7 @@
 		OFFSET_NECK_F = list(0,-1), OFFSET_MOUTH_F = list(0,-1), OFFSET_PANTS_F = list(0,0), \
 		OFFSET_SHIRT_F = list(0,0), OFFSET_ARMOR_F = list(0,0), OFFSET_UNDIES_F = list(0,-1), \
 		)
-	race_bonus = list(STAT_ENDURANCE = 1, STAT_CONSTITUTION = 1)
+	race_bonus = list(STAT_ENDURANCE = 2, STAT_CONSTITUTION = 1, STAT_PERCEPTION = -1)
 	enflamed_icon = "widefire"
 	attack_verb = "slash"
 	attack_sound = 'sound/blank.ogg'

--- a/code/modules/mob/living/carbon/human/species_types/furry/anthromorphsmall.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/anthromorphsmall.dm
@@ -5,7 +5,7 @@
 	name = "Verminvolk"
 	id = "anthromorphsmall"
 	desc = "A race akin to wild-kin, except afflicted with significantly smaller stature. A bit less respected than their kin due to their closer resemblance to vermin, like the dichotomy between Kobold and Sissean.<br>\
-	(+1 Speed)"
+	(+2 Speed, +1 Intelligence, -1 Strength, -1 Constitution)"
 	default_color = "444"
 	species_traits = list(
 		MUTCOLORS,
@@ -38,7 +38,7 @@
 		OFFSET_NECK_F = list(0,-5), OFFSET_MOUTH_F = list(0,-5), OFFSET_PANTS_F = list(0,0), \
 		OFFSET_SHIRT_F = list(0,0), OFFSET_ARMOR_F = list(0,0), OFFSET_UNDIES_F = list(0,-4), \
 		)
-	race_bonus = list(STAT_SPEED = 1)
+	race_bonus = list(STAT_SPEED = 2, STAT_STRENGTH = -1, STAT_CONSTITUTION = -1, STAT_INTELLIGENCE = 1)
 	enflamed_icon = "widefire"
 	organs = list(
 		ORGAN_SLOT_BRAIN = /obj/item/organ/brain,

--- a/code/modules/mob/living/carbon/human/species_types/furry/dracon.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/dracon.dm
@@ -6,7 +6,7 @@
 	id = "dracon"
 	desc = "<b>Drakian</b><br>\
 	Mighty scaled individuals who claim to be descendants of the dragons of yore.<br>\
-	(+1 Strength)"
+	(+1 Strength, +1 Intelligence, -1 Perception)"
 	species_traits = list(EYECOLOR,LIPS,STUBBLE,MUTCOLORS)
 	possible_ages = ALL_AGES_LIST
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | RACE_SWAP | SLIME_EXTRACT
@@ -28,7 +28,7 @@
 		OFFSET_NECK_F = list(0,-1), OFFSET_MOUTH_F = list(0,-1), OFFSET_PANTS_F = list(0,0), \
 		OFFSET_SHIRT_F = list(0,0), OFFSET_ARMOR_F = list(0,0), OFFSET_UNDIES_F = list(0,-1), \
 		)
-	race_bonus = list(STAT_STRENGTH = 1)
+	race_bonus = list(STAT_STRENGTH = 1, STAT_INTELLIGENCE = 1, STAT_PERCEPTION = -1)
 	enflamed_icon = "widefire"
 	attack_verb = "slash"
 	attack_sound = 'sound/blank.ogg'

--- a/code/modules/mob/living/carbon/human/species_types/furry/kobold.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/kobold.dm
@@ -6,7 +6,7 @@
 	id = "kobold"
 	desc = "<b>Kobold</b><br>\
 	Short in stature and typically scrawny, these little lizards make up for it in their natural agility. People typically stereotype them as thieves, though...<br>\
-	(+1 Fortune)"
+	(+1 Fortune, +1 Speed, -1 Strength)"
 	species_traits = list(EYECOLOR,LIPS,STUBBLE,MUTCOLORS)
 	possible_ages = ALL_AGES_LIST
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | RACE_SWAP | SLIME_EXTRACT
@@ -31,7 +31,7 @@
 		OFFSET_NECK_F = list(0,-5), OFFSET_MOUTH_F = list(0,-5), OFFSET_PANTS_F = list(0,0), \
 		OFFSET_SHIRT_F = list(0,0), OFFSET_ARMOR_F = list(0,0), OFFSET_UNDIES = list(0,-4), OFFSET_UNDIES_F = list(0,-4), \
 		)
-	race_bonus = list(STAT_FORTUNE = 1)
+	race_bonus = list(STAT_FORTUNE = 1, STAT_STRENGTH = -1, STAT_SPEED = 1)
 	enflamed_icon = "widefire"
 	attack_verb = "slash"
 	attack_sound = 'sound/blank.ogg'

--- a/code/modules/mob/living/carbon/human/species_types/furry/lizardfolk.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/lizardfolk.dm
@@ -10,7 +10,7 @@
 	Taller than humans and powerfully built, sisseans are often between 6 and 7 feet tall. \
 	Sisseans have non-prehensile muscular tails that grow to three or four feet in length, and these are used for balance. \
 	They also have sharp claws and teeth.<br>\
-	(+1 Constitution, +1 Endurance)"
+	(+2 Constitution, +2 Endurance, -1 Speed)"
 	skin_tone_wording = "Skin Colors"
 	species_traits = list(EYECOLOR,LIPS,STUBBLE,MUTCOLORS)
 	possible_ages = ALL_AGES_LIST
@@ -33,7 +33,7 @@
 		OFFSET_NECK_F = list(0,-1), OFFSET_MOUTH_F = list(0,-1), OFFSET_PANTS_F = list(0,0), \
 		OFFSET_SHIRT_F = list(0,0), OFFSET_ARMOR_F = list(0,0), OFFSET_UNDIES_F = list(0,-1), \
 		)
-	race_bonus = list(STAT_CONSTITUTION = 1, STAT_ENDURANCE = 1)
+	race_bonus = list(STAT_CONSTITUTION = 2, STAT_ENDURANCE = 2, STAT_SPEED = -1)
 	enflamed_icon = "widefire"
 	attack_verb = "slash"
 	attack_sound = 'sound/blank.ogg'

--- a/code/modules/mob/living/carbon/human/species_types/furry/lupian.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/lupian.dm
@@ -11,7 +11,7 @@
 	warriors to those who earn their loyalty. Thanks to their pack minded nature they are slow to trust the other races \
 	but form deep connections with those they do. In recent years they have been driven from the forests by unrest and pressed \
 	into cohabitation with races they'd deem lesser.<br>\
-	(+1 Constitution, +1 Intelligence)"
+	(+2 Constitution, +1 Intelligence, +1 Endurance, -1 Speed)"
 	skin_tone_wording = "Pack"
 	species_traits = list(
 		MUTCOLORS,
@@ -43,7 +43,7 @@
 		OFFSET_NECK_F = list(0,-1), OFFSET_MOUTH_F = list(0,-1), OFFSET_PANTS_F = list(0,0), \
 		OFFSET_SHIRT_F = list(0,0), OFFSET_ARMOR_F = list(0,0), OFFSET_UNDIES_F = list(0,-1), \
 		)
-	race_bonus = list(STAT_INTELLIGENCE = 1, STAT_CONSTITUTION = 1)
+	race_bonus = list(STAT_INTELLIGENCE = 1, STAT_CONSTITUTION = 2, STAT_ENDURANCE = 1, STAT_SPEED = -1)
 	enflamed_icon = "widefire"
 	organs = list(
 		ORGAN_SLOT_BRAIN = /obj/item/organ/brain,

--- a/code/modules/mob/living/carbon/human/species_types/furry/moth.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/moth.dm
@@ -5,7 +5,7 @@
 	name = "Fluvian"
 	id = "moth"
 	desc = "A curious, insectoid creature that almost seems out of place. Uniquely, despite their size, they're capable of flight!<br>\
-	(+1 Speed)"
+	(+1 Speed, +1 Intelligence, -1 Constitution)"
 	species_traits = list(EYECOLOR,LIPS,STUBBLE,MUTCOLORS,HAIR)
 	possible_ages = ALL_AGES_LIST
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | RACE_SWAP | SLIME_EXTRACT
@@ -27,7 +27,7 @@
 		OFFSET_NECK_F = list(0,-1), OFFSET_MOUTH_F = list(0,-1), OFFSET_PANTS_F = list(0,0), \
 		OFFSET_SHIRT_F = list(0,0), OFFSET_ARMOR_F = list(0,0), OFFSET_UNDIES_F = list(0,-1), \
 		)
-	race_bonus = list(STAT_SPEED = 1)
+	race_bonus = list(STAT_SPEED = 1, STAT_INTELLIGENCE = 1, STAT_CONSTITUTION = -1)
 	enflamed_icon = "widefire"
 	attack_verb = "slash"
 	attack_sound = 'sound/blank.ogg'

--- a/code/modules/mob/living/carbon/human/species_types/furry/tabaxi.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/tabaxi.dm
@@ -14,7 +14,7 @@
 		Tabaxi eyes are slit-pupilled and usually green or yellow. \
 		Tabaxi are competent swimmers and climbers as well as speedy runners. \
 		They have a good sense of balance and an acute sense of smell.<br>\
-		(+1 Speed)"
+		(+1 Speed)(+1 Perception)(-1 End)"
 	skin_tone_wording = "Fur Colors"
 	species_traits = list(EYECOLOR,HAIR,FACEHAIR,LIPS,STUBBLE, MUTCOLORS)
 	possible_ages = ALL_AGES_LIST
@@ -37,7 +37,7 @@
 		OFFSET_NECK_F = list(0,-1), OFFSET_MOUTH_F = list(0,-1), OFFSET_PANTS_F = list(0,0), \
 		OFFSET_SHIRT_F = list(0,0), OFFSET_ARMOR_F = list(0,0), OFFSET_UNDIES_F = list(0,-1)
 		)
-	race_bonus = list(STAT_SPEED = 1)
+	race_bonus = list(STAT_SPEED = 1, STAT_PERCEPTION = 1, STAT_ENDURANCE = -1)
 	enflamed_icon = "widefire"
 	organs = list(
 		ORGAN_SLOT_BRAIN = /obj/item/organ/brain,

--- a/code/modules/mob/living/carbon/human/species_types/furry/vulpkanin.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/vulpkanin.dm
@@ -5,7 +5,7 @@
 	name = "Vulpkian"
 	id = "vulpkanin"
 	desc = "Foxy creatures known for their cleverness and mischief. In ancient history they were Dendor's original champions, but as His madness grew the connect became frey and forgotten, leaving them to their own devices. Or, at least, that's what they say.<br>\
-	(+1 Intelligence, +1 Perception)"
+	(+1 Intelligence, +2 Perception, -1 Constitution)"
 	default_color = "444"
 	species_traits = list(
 		MUTCOLORS,
@@ -34,7 +34,7 @@
 		OFFSET_NECK_F = list(0,-1), OFFSET_MOUTH_F = list(0,-1), OFFSET_PANTS_F = list(0,0), \
 		OFFSET_SHIRT_F = list(0,0), OFFSET_ARMOR_F = list(0,0), OFFSET_UNDIES_F = list(0,-1), \
 		)
-	race_bonus = list(STAT_PERCEPTION = 1, STAT_INTELLIGENCE = 1)
+	race_bonus = list(STAT_PERCEPTION = 2, STAT_INTELLIGENCE = 1, STAT_CONSTITUTION = -1)
 	enflamed_icon = "widefire"
 	organs = list(
 		ORGAN_SLOT_BRAIN = /obj/item/organ/brain,

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/dwarf/dwarfm.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/dwarf/dwarfm.dm
@@ -19,7 +19,7 @@
 	to improve their crafts, both in engineering workshops and the forges. \
 	Dwarves are hearty, but are not known for their speed or eyesight... \
 	Each dwarf hails from a ancient fortress named after the most plentiful mineral.<br>\
-	(+1 Constitution, +1 Endurance)"
+	(+2 Constitution, +2 Endurance, +1 Strength, -2 Speed)"
 
 	skin_tone_wording = "Dwarf Fortress"
 
@@ -52,7 +52,7 @@
 		OFFSET_NECK_F = list(0,-5), OFFSET_MOUTH_F = list(0,-5), OFFSET_PANTS_F = list(0,0), \
 		OFFSET_SHIRT_F = list(0,0), OFFSET_ARMOR_F = list(0,0), OFFSET_UNDIES = list(0,-4), OFFSET_UNDIES_F = list(0,-4), \
 		)
-	race_bonus = list(STAT_CONSTITUTION = 1, STAT_ENDURANCE = 1)
+	race_bonus = list(STAT_CONSTITUTION = 2, STAT_ENDURANCE = 2, STAT_STRENGTH = 1, STAT_SPEED = -2)
 	enflamed_icon = "widefire"
 	customizers = list(
 		/datum/customizer/organ/eyes/humanoid,

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/elf/elfs.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/elf/elfs.dm
@@ -17,7 +17,7 @@
 	relationships, which are capable of producing half-elven children. Elves are known for \
 	their intelligence and sharp eyes, but their graceful nature typically leaves their bodies \
 	more frail and fagile than most. In these lands, only a handful of the many Elvish tribes are seen.<br>\
-	(+1 Speed)"
+	(+1 Speed, +1 Intelligence, +2 Perception, -1 Strength, -1 Constitution)"
 
 	skin_tone_wording = "Tribal Identity"
 
@@ -48,7 +48,7 @@
 		OFFSET_NECK_F = list(0,-1), OFFSET_MOUTH_F = list(0,-1), OFFSET_PANTS_F = list(0,0), \
 		OFFSET_SHIRT_F = list(0,0), OFFSET_ARMOR_F = list(0,0), OFFSET_UNDIES_F = list(0,-1), \
 		)
-	race_bonus = list(STAT_SPEED = 1)
+	race_bonus = list(STAT_SPEED = 1, STAT_INTELLIGENCE = 1, STAT_PERCEPTION = 2, STAT_STRENGTH = -1, STAT_CONSTITUTION = -1)
 	enflamed_icon = "widefire"
 	organs = list(
 		ORGAN_SLOT_BRAIN = /obj/item/organ/brain,

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/goblin/goblinp.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/goblin/goblinp.dm
@@ -9,7 +9,7 @@
 	mindless, enthralled waves of the creatures to attack civilization from lunar portals. It leaves the typical goblinoid to cloister in their hidden away tribes, stealing \
 	from the scraps out of fear of reprisal while shooing away outsiders. The cities of Man typically shun them, but it's not unheard of to see one pushing their luck in a \
 	town square or out on a well-traveled road, as even the most backwater peasant can tell the difference between a sapient one and portal-spawn. Usually.<br>\
-	(+1 Speed)" 
+	(+1 Speed, +1 Intelligence, +1 Fortune, -1 Strength)" 
 	species_traits = list(EYECOLOR,LIPS,STUBBLE)
 	possible_ages = ALL_AGES_LIST
 	use_skintones = TRUE
@@ -50,7 +50,7 @@
 		OFFSET_NECK_F = list(0,-5), OFFSET_MOUTH_F = list(0,-5), OFFSET_PANTS_F = list(0,0), \
 		OFFSET_SHIRT_F = list(0,0), OFFSET_ARMOR_F = list(0,0), OFFSET_UNDIES_F = list(0,-4), \
 		)
-	race_bonus = list(STAT_SPEED = 1)
+	race_bonus = list(STAT_SPEED = 1, STAT_STRENGTH = -1, STAT_FORTUNE = 1, STAT_INTELLIGENCE = 1)
 	enflamed_icon = "widefire"
 	attack_verb = "slash"
 	attack_sound = 'sound/blank.ogg'

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/human/humen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/human/humen.dm
@@ -12,7 +12,7 @@
 	have historically been at odds with one another. Being the eldest creations of the Weeping God, humens \
 	tend to find fortune easier than the other races, and are so diverse that no other racial traits \
 	are dominant in their species.<br>\
-	(+1 Endurance, +1 Intelligence)"
+	(+2 Endurance, +1 Intelligence, -1 Perception)"
 
 	skin_tone_wording = "Ancestry"
 
@@ -42,7 +42,7 @@
 		OFFSET_NECK_F = list(0,-1), OFFSET_MOUTH_F = list(0,-1), OFFSET_PANTS_F = list(0,0), \
 		OFFSET_SHIRT_F = list(0,0), OFFSET_ARMOR_F = list(0,0), OFFSET_UNDIES_F = list(0,-1), \
 		)
-	race_bonus = list(STAT_INTELLIGENCE = 1, STAT_ENDURANCE = 1)
+	race_bonus = list(STAT_INTELLIGENCE = 1, STAT_ENDURANCE = 2, STAT_PERCEPTION = -1)
 	enflamed_icon = "widefire"
 	customizers = list(
 		/datum/customizer/organ/eyes/humanoid,

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/halforc.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/halforc.dm
@@ -14,7 +14,7 @@
 	people cannot decide between regarding you with either mere distrust or outright disgust. Yet \
 	somehow your wandering feet came to Blackmoor, where half-orcs ply muscle and their hardiness \
 	in the rough underbelly or outer reaches of society.<br>\
-	(+1 Strength)"
+	(+1 Strength, +1 Endurance, +1 Constitution, -2 Intelligence)"
 
 	skin_tone_wording = "Clan"
 
@@ -43,7 +43,7 @@
 	OFFSET_FACE_F = list(0,1), OFFSET_BELT_F = list(0,1), OFFSET_BACK_F = list(0,1), \
 	OFFSET_NECK_F = list(0,1), OFFSET_MOUTH_F = list(0,1), OFFSET_PANTS_F = list(0,1), \
 	OFFSET_SHIRT_F = list(0,1), OFFSET_ARMOR_F = list(0,1), OFFSET_UNDIES_F = list(0,1))
-	race_bonus = list(STAT_STRENGTH = 1)
+	race_bonus = list(STAT_STRENGTH = 1, STAT_CONSTITUTION = 1, STAT_ENDURANCE = 1, STAT_INTELLIGENCE = -2)
 	enflamed_icon = "widefire"
 	organs = list(
 		ORGAN_SLOT_BRAIN = /obj/item/organ/brain,

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/tiefling.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/tiefling.dm
@@ -13,7 +13,7 @@
 	The taint of their very being going back generations, and no amount of cleansing can be rid of it. \
 	As over a millennium a simple handful of Tieflings have created extended bloodlines linking back to their infernal progenitors. Some Tieflings embrace their demonic origin, while other shun it. \
 	No matter if they embrace their demonic ancestors or not, Tieflings have formed an importance upon their bloodline and family due to often being shunned and hunted through out time in which only those of their blood and kin they could truly trust. <br>\
-	(+1 Constitution, +1 Intelligence)"
+	(+1 Constitution, +2 Intelligence, Fortune -1)"
 
 	skin_tone_wording = "Progenitor"
 
@@ -43,7 +43,7 @@
 		OFFSET_NECK_F = list(0,-1), OFFSET_MOUTH_F = list(0,-1), OFFSET_PANTS_F = list(0,0), \
 		OFFSET_SHIRT_F = list(0,0), OFFSET_ARMOR_F = list(0,0), OFFSET_UNDIES_F = list(0,-1), \
 		)
-	race_bonus = list(STAT_INTELLIGENCE = 1, STAT_CONSTITUTION = 1)
+	race_bonus = list(STAT_INTELLIGENCE = 2, STAT_CONSTITUTION = 1, STAT_FORTUNE = -1)
 	enflamed_icon = "widefire"
 	organs = list(
 		ORGAN_SLOT_BRAIN = /obj/item/organ/brain,


### PR DESCRIPTION
## About The Pull Request

Please read the actual statchanges from the filechange, as putting this in a table would be very annoying.

Makes all races a tiny bit more distinct, by actually daring to give -stats, and then compensating with the expected positive stats. The stat BALANCE, using the assumed weighted point system azure peak uses (STR and SPD count double) is the SAME. 
You will MOSTLY be able to mitigate things using statpacks, as these racial stats are still quite mild for the majority of races, somewhere inbetween Ratwood and AP.

## Testing Evidence

I compiled, ran this, and spawned in as some of the races, and had the expected stats applied.

## Why It's Good For The Game

A bit more immersion, a kobold is a lot speedier than a dwarf, but the dwarf sure is hardier. Half-Orcs are somewhat dumber, but they are tough as they come. Elves ARE a bit weaker than humen, and they don't have the impressive stamina of humen either, but their keen ears are unmatched.. etc. etc..
The actual stats being changed etc. and to what degree is completely up in the air! I just wanted to make this pr and see what Neo has to say about this regarding the direction of this server.