### PR TITLE
Nerfs Dragonring

### DIFF
--- a/code/modules/clothing/rogueclothes/rings.dm
+++ b/code/modules/clothing/rogueclothes/rings.dm
@@ -181,18 +181,18 @@
 	else if(slot == SLOT_RING)
 		active_item = TRUE
 		to_chat(user, span_notice("Here be dragons."))
-		user.change_stat("strength", 5)
-		user.change_stat("constitution", 5)
-		user.change_stat("endurance", 5)
+		user.change_stat("strength", 2)
+		user.change_stat("constitution", 2)
+		user.change_stat("endurance", 2)
 	return
 
 /obj/item/clothing/ring/dragon_ring/dropped(mob/living/user)
 	..()
 	if(active_item)
 		to_chat(user, span_notice("Gone is thy hoard."))
-		user.change_stat("strength", -5)
-		user.change_stat("constitution", -5)
-		user.change_stat("endurance", -5)
+		user.change_stat("strength", -2)
+		user.change_stat("constitution", -2)
+		user.change_stat("endurance", -2)
 		active_item = FALSE
 	return
 


### PR DESCRIPTION
## About The Pull Request

Due to dungeonloot and alchemy, dragonrings are quite a lot easier to acquire than on for example ratwood. Yet they are significantly stronger.
A dragon ring gives you +5str,con,end basically turning you into an absolute megagod. Please remember that this lets you always chargecheck people from 1 tile away, and that str damage bonus is not capped here unlike AP.
Stamina is actually incredibly important on AP code, so 5 end is also amazing.

This pr changes it to +2 instead, making it very powerful but not quite as oppressive.

## Testing Evidence
I compiled and checked the statgain locally.
## Why It's Good For The Game
1. It's too easy to get if you codedive and shit. We do not want secret code and map knowers abusing this obscure item.
2. We don't want powergamers rushing this.
3. We probably do not a ring more powerful than +2 craftable, at all.