### PR TITLE
Nerfs throwing weapons

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/knives.dm
+++ b/code/game/objects/items/rogueweapons/melee/knives.dm
@@ -431,10 +431,10 @@
 	desc = "Paradoxical; why is it called a blade when it is meant for tossing? Or is it the act of cutting post-toss that makes it a blade? ...Are arrows tossblades, too?"
 	item_state = "bone_dagger"
 	force = 10
-	throwforce = 22
-	throw_speed = 4
+	throwforce = 15
+	throw_speed = 1.5
 	max_integrity = 50
-	armor_penetration = 30
+	armor_penetration = 0
 	wdefense = 1
 	icon_state = "throw_knifei"
 	embedding = list("embedded_pain_multiplier" = 4, "embed_chance" = 25, "embedded_fall_chance" = 10)
@@ -457,15 +457,14 @@
 	desc = "A decrepit old tossblade. You ought to throw cutlery instead."
 	icon_state = "throw_knifea"
 	force = 7
-	throwforce = 16
+	throwforce = 13
 
 /obj/item/rogueweapon/huntingknife/throwingknife/steel
 	name = "steel tossblade"
 	desc = "There are rumors of some sea-marauders loading these into metal tubes with explosive powder to launch then fast and far. Probably won't catch on."
 	item_state = "bone_dagger"
-	throwforce = 28
 	max_integrity = 100
-	armor_penetration = 40
+	armor_penetration = 10
 	icon_state = "throw_knifes"
 	embedding = list("embedded_pain_multiplier" = 4, "embed_chance" = 30, "embedded_fall_chance" = 5)
 	sellprice = 2

--- a/code/game/objects/items/rogueweapons/ranged/ammo.dm
+++ b/code/game/objects/items/rogueweapons/ranged/ammo.dm
@@ -512,43 +512,42 @@
 //Only ammo casing, no 'projectiles'. You throw the casing, as weird as it is.
 /obj/item/ammo_casing/caseless/rogue/javelin
 	force = 14
-	throw_speed = 3		//1 lower than throwing knives, it hits harder + embeds more.
+	throw_speed = 1		//0.5 lower than throwing knives, it hits harder + embeds more.
 	name = "iron javelin"
 	desc = "A tool used for centuries, as early as recorded history. This one is tipped with a iron head; standard among militiamen and irregulars alike."
 	icon = 'icons/roguetown/weapons/ammo.dmi'
 	icon_state = "ijavelin"
 	wlength = WLENGTH_NORMAL
 	w_class = WEIGHT_CLASS_BULKY
-	armor_penetration = 40					//Redfined because.. it's not a weapon, it's an 'arrow' basically.
+	armor_penetration = 0					//Redfined because.. it's not a weapon, it's an 'arrow' basically. Zero because we are going against piercing values on armour.
 	max_integrity = 50						//Breaks semi-easy, stops constant re-use. 
-	wdefense = 3							//Worse than a spear
+	wdefense = 3							//Worse than a spear.
 	thrown_bclass = BCLASS_STAB				//Knives are slash, lets try out stab and see if it's too strong in terms of wounding.
-	throwforce = 25							//throwing knife is 22, slightly better for being bulkier.
+	throwforce = 20							//throwing knife is 15, slightly better for being bulkier.
 	possible_item_intents = list(/datum/intent/sword/thrust, /datum/intent/spear/bash, /datum/intent/spear/cut)	//Sword-thrust to avoid having 2 reach.
 	embedding = list("embedded_pain_multiplier" = 4, "embed_chance" = 35, "embedded_fall_chance" = 10)	//Better than iron throwing knife by 10%
 	anvilrepair = /datum/skill/craft/weaponsmithing
 	smeltresult = /obj/item/ingot/iron
 	associated_skill = /datum/skill/combat/polearms
-	heavy_metal = FALSE						//Stops spin animation, maybe.
-	thrown_damage_flag = "piercing"			//Checks peircing protection.
+	heavy_metal = FALSE						//Stops spin animation.
+	thrown_damage_flag = "piercing"			//Checks piercing protection.
 
 /obj/item/ammo_casing/caseless/rogue/javelin/aalloy
 	name = "decrepit javelin"
 	desc = "A decrepit old javelin, surely used centuries ago. Aeon's grasp is upon its form."
 	icon_state = "ajavelin"
 	smeltresult = /obj/item/ingot/aalloy
-	throwforce = 20
+	throwforce = 18
 	force = 9
 
 /obj/item/ammo_casing/caseless/rogue/javelin/steel
 	force = 16
-	armor_penetration = 50
+	armor_penetration = 10
 	name = "steel javelin"
 	desc = "A tool used for centuries, as early as recorded history. This one is tipped with a steel head; perfect for piercing armor!"
 	icon_state = "javelin"
 	max_integrity = 100						//In-line with other stabbing weapons.
-	throwforce = 28							//Equal to steel knife BUT this has peircing damage type so..
-	thrown_bclass = BCLASS_PICK				//Bypasses crit protection better than stabbing. Makes it better against heavy-targets.
+	thrown_bclass = BCLASS_STAB
 	embedding = list("embedded_pain_multiplier" = 4, "embed_chance" = 45, "embedded_fall_chance" = 10) //Better than steel throwing knife by 10%
 	smeltresult = /obj/item/ingot/steel
 
@@ -558,7 +557,7 @@
 	icon_state = "ajavelin"
 	smeltresult = /obj/item/ingot/aaslag
 
-/obj/item/ammo_casing/caseless/rogue/javelin/silver
+ /obj/item/ammo_casing/caseless/rogue/javelin/silver
 	name = "silver javelin"
 	desc = "A tool used for centuries, as early as recorded history. This one appears to be tipped with a silver head. Decorative, perhaps.. or for some sort of specialized hunter."
 	icon_state = "sjavelin"

--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/weapons.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/weapons.dm
@@ -718,19 +718,19 @@
 	created_item = /obj/item/rogueweapon/mace/silver
 	craftdiff = 3
 
-/datum/anvil_recipe/weapons/silver/tossblade
-	name = "Silver Tossblades 4x"
-	req_bar = /obj/item/ingot/silver
-	created_item = /obj/item/rogueweapon/huntingknife/throwingknife/psydon
-	craftdiff = 3
-	createditem_num = 4
+// /datum/anvil_recipe/weapons/silver/tossblade
+//	name = "Silver Tossblades 4x"
+//	req_bar = /obj/item/ingot/silver
+//	created_item = /obj/item/rogueweapon/huntingknife/throwingknife/psydon
+//	craftdiff = 3
+//	createditem_num = 4
 
-/datum/anvil_recipe/weapons/silver/javelin
-	name = "Silver Javelin (+1 Small Log)"
-	req_bar = /obj/item/ingot/silver
-	additional_items = list(/obj/item/grown/log/tree/small)
-	created_item = /obj/item/ammo_casing/caseless/rogue/javelin/silver
-	craftdiff = 3
+// /datum/anvil_recipe/weapons/silver/javelin
+//	name = "Silver Javelin (+1 Small Log)"
+//	req_bar = /obj/item/ingot/silver
+//	additional_items = list(/obj/item/grown/log/tree/small)
+//	created_item = /obj/item/ammo_casing/caseless/rogue/javelin/silver
+//	craftdiff = 3
 
 
 // ------ BRONZE ------


### PR DESCRIPTION
## About The Pull Request
- javelins and knives no longer instantly materialize to their target and can be dodged now
- steel javelins no longer first hit crit through plate
- you can no longer smith silver javelins and silver throwing knives 
- lowered thrown damage values for both item archetypes



<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

https://github.com/user-attachments/assets/bec5ad80-f91f-4be1-b61a-e0f1db465cd5

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

steel javelins have been infamous since i started playing here, and seeing the code to it as well as everyone run around with the javelin bags to get epic frags with no counterplay made me feel that this change is needed.

especially javelins can be concealed easily on the sprite and thrown twice in quick succession, almost always critting the targetted limb in two hits due to PICK damage class and piercing damage type, perfectly penetrating almost all armour in the game. these in turn were also undodgeable due to travelling at thrice the speed of any other thrown item.

javelins and tossblades, unlike every other ranged option, do not require you to charge up a throw or shot as well as not really being all that reliant on PER as well as completely usable by everyone, due to no associated skill...

therefore getting hit with a javelin should be significantly less dangerous than being hit by an arrow.

ontop of this i chose to make the silver variants uncraftable, commenting out the code. if you want to apply a silver debuff on  an antag you should be in melee range to do it.

steel javelins and tossblades still have some AP, this means they will deal some damage through chain as well as full damage through maille, while bouncing off of plate and sticking to padded gambesons. you will actually have to aim for weakspots to be effective, but even then- hitting two or three throws before going to melee will see your opponent with about 30% less armour durability, making these weapons still useful without being total fragmachines.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
