### PR TITLE
Fixes Fireball and Burn Damage from Fire

### DIFF
--- a/code/controllers/subsystem/fire_burning.dm
+++ b/code/controllers/subsystem/fire_burning.dm
@@ -31,7 +31,7 @@ SUBSYSTEM_DEF(fire_burning)
 
 		if(O.resistance_flags & ON_FIRE) //in case an object is extinguished while still in currentrun
 			if(!(O.resistance_flags & FIRE_PROOF))
-				O.take_damage(15, BURN, "fire", 0)
+				O.take_damage(1, BURN, "fire", 0)
 			else
 				O.extinguish()
 			if(!O.fire_burn_start)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1862,7 +1862,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		burn_damage = burn_damage * heatmod * H.physiology.heat_mod
 		if (H.stat < UNCONSCIOUS && (prob(burn_damage) * 10) / 4) //40% for level 3 damage on humans
 			H.emote("pain")
-		H.apply_damage(CLAMP(burn_damage, 0, 15), BURN, spread_damage = TRUE) //Azure buffing fireball then forgetting to cap burn damage, classic L
+		H.apply_damage(CLAMP(burn_damage, 0, 25), BURN, spread_damage = TRUE) //Azure buffing fireball then forgetting to cap burn damage, classic L
 
 	else if(H.bodytemperature < BODYTEMP_COLD_DAMAGE_LIMIT && !HAS_TRAIT(H, TRAIT_RESISTCOLD))
 		SEND_SIGNAL(H, COMSIG_CLEAR_MOOD_EVENT, "hot")

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1862,7 +1862,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		burn_damage = burn_damage * heatmod * H.physiology.heat_mod
 		if (H.stat < UNCONSCIOUS && (prob(burn_damage) * 10) / 4) //40% for level 3 damage on humans
 			H.emote("pain")
-		H.apply_damage(burn_damage, BURN, spread_damage = TRUE)
+		H.apply_damage(CLAMP(burn_damage, 0, 15), BURN, spread_damage = TRUE) //Azure buffing fireball then forgetting to cap burn damage, classic L
 
 	else if(H.bodytemperature < BODYTEMP_COLD_DAMAGE_LIMIT && !HAS_TRAIT(H, TRAIT_RESISTCOLD))
 		SEND_SIGNAL(H, COMSIG_CLEAR_MOOD_EVENT, "hot")

--- a/code/modules/spells/spell_types/wizard/projectiles_aoe/fireball.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_aoe/fireball.dm
@@ -30,7 +30,7 @@
 	exp_light = 1
 	exp_flash = 2
 	exp_fire = 1
-	damage = 20
+	damage = 35
 	damage_type = BURN
 	accuracy = 40 // Base accuracy is lower for burn projectiles because they bypass armor
 	nodamage = FALSE

--- a/code/modules/spells/spell_types/wizard/projectiles_aoe/fireball.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_aoe/fireball.dm
@@ -27,8 +27,8 @@
 /obj/projectile/magic/aoe/fireball/rogue
 	name = "fireball"
 	exp_heavy = 0
-	exp_light = 0
-	exp_flash = 0
+	exp_light = 1
+	exp_flash = 2
 	exp_fire = 0
 	damage = 20
 	damage_type = BURN

--- a/code/modules/spells/spell_types/wizard/projectiles_aoe/fireball.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_aoe/fireball.dm
@@ -29,8 +29,8 @@
 	exp_heavy = 0
 	exp_light = 0
 	exp_flash = 0
-	exp_fire = 1
-	damage = 10
+	exp_fire = 0
+	damage = 20
 	damage_type = BURN
 	accuracy = 40 // Base accuracy is lower for burn projectiles because they bypass armor
 	nodamage = FALSE
@@ -42,9 +42,13 @@
 /obj/projectile/magic/aoe/fireball/rogue/on_hit(target)
 	. = ..()
 	if(ismob(target))
-		var/mob/M = target
+		var/mob/living/M = target
 		if(M.anti_magic_check())
 			visible_message(span_warning("[src] fizzles on contact with [target]!"))
 			playsound(get_turf(target), 'sound/magic/magic_nulled.ogg', 100)
 			qdel(src)
 			return BULLET_ACT_BLOCK
+		else
+			M.adjust_fire_stacks(5) //Compensates for it losing instant death capabilities
+			M.IgniteMob()
+

--- a/code/modules/spells/spell_types/wizard/projectiles_aoe/fireball.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_aoe/fireball.dm
@@ -29,7 +29,7 @@
 	exp_heavy = 0
 	exp_light = 1
 	exp_flash = 2
-	exp_fire = 0
+	exp_fire = 1
 	damage = 20
 	damage_type = BURN
 	accuracy = 40 // Base accuracy is lower for burn projectiles because they bypass armor


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->
retarded change being unretarded
## Testing Evidence
It compiles and thus it must work

Test it ingame if you really want to see the effects this PR has. Fireball is still lethal as fuck but no longer one-beams you.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
I shouldn't have to explain why objects taking 15 burn damage per tick making fireball one of the best spells for destroying doors, walls, and other objects is bad.

Caps fire to 15 distributed damage per second instead of like before where it could do literally infinite damage based on your firestacks, which you got hundreds of from fireball due to how the spell works

lol lmao

Also I guess minorly buffs fireball in exchange for losing it's fire radius as thats why you were getting so many firestacks, instead makes it more akin to D&D slop fireball where casting it in a small space is a really bad idea.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
