### PR TITLE
fixes deserterwretch lance spawn shield

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/deserter.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/deserter.dm
@@ -69,7 +69,7 @@
 					backr = /obj/item/rogueweapon/stoneaxe/battle
 				if("Lance + Kite Shield")
 					r_hand = /obj/item/rogueweapon/spear/lance
-					backl = /obj/item/rogueweapon/shield/tower/metal
+					backr = /obj/item/rogueweapon/shield/tower/metal
 			var/helmets = list(
 				"Pigface Bascinet" 	= /obj/item/clothing/head/roguetown/helmet/bascinet/pigface,
 				"Guard Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/guard,


### PR DESCRIPTION
## About The Pull Request

makes lance disgraced deserter actually start with the shield they are supposed to, this was just bugged

## Testing Evidence

![XaheHS5](https://github.com/user-attachments/assets/26c855b3-8e6c-43b7-a50e-5e1a8cbb8bc6)


## Why It's Good For The Game

it says you get it so you should, alternative is removing it from the description