### PR TITLE
wretch no longer gets +1 ALL stats for nothing

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
@@ -62,11 +62,10 @@
 				ADD_TRAIT(H, TRAIT_NOHUNGER, TRAIT_GENERIC)
 				ADD_TRAIT(H, TRAIT_NOBREATH, TRAIT_GENERIC)
 				ADD_TRAIT(H, TRAIT_NOPAIN, TRAIT_GENERIC)
-        		ADD_TRAIT(H, TRAIT_NOROGSTAM, TRAIT_GENERIC)
-        
-			to_chat(H, span_danger("The thirst for blood burns within you, but you are merely one of many cursed with vampirism."))
-			// Apply -3 to fortune
-			H.change_stat("fortune", -3)
+				ADD_TRAIT(H, TRAIT_NOROGSTAM, TRAIT_GENERIC)
+				to_chat(H, span_danger("The thirst for blood burns within you, but you are merely one of many cursed with vampirism."))
+				// Apply -3 to fortune
+				H.change_stat("fortune", -3)
 		if("Werewolf (-3 to fortune)")
 			var/datum/antagonist/werewolf/lesser/antag = H.mind.add_antag_datum(/datum/antagonist/werewolf/lesser)
 			if(antag) antag.wretch_antag = TRUE


### PR DESCRIPTION
## About The Pull Request

a speedmerged PR made normal wretches gain +1 to ALL stats for.. not being a vampire/ww, turning wretches into the highest stat monsters in the entire game, by far, for no apparent reason.

This:
makes it so normal wretches gain nothing
vampyres/ww do not lose -1 to all stats, and instead lose -3 fortune (to represent being cursed)

## Testing Evidence
![edQ3B4g](https://github.com/user-attachments/assets/1f7657a8-d443-452e-b6c3-3fd4f76d3e72)
![eluuU34](https://github.com/user-attachments/assets/3e3b6c73-1cc6-4808-afa6-64aefc015f49)
thuggish statpack humen disgraced knight wretch note the 8 vs 7 supposed fortune because I had thuggish selected and it rolled +1

## Why It's Good For The Game

wretches probably shouldnt probably receive a +1 to all fucking stats in a hidden away place, and probably shouldnt be the strongest thing by fucking far
vamps and ww interact weirdly with a lot of stats and a blanket -1 to all nerf is sloppy and idiotic. -3 Fortune is thematically more appropriate, functions even when ww forcesets a bunch of stats to 20.
