### PR TITLE
Young hands + Slight Reflavor to Account for this

### DIFF
--- a/code/modules/jobs/job_types/roguetown/nobility/hand.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/hand.dm
@@ -13,8 +13,6 @@
 	advclass_cat_rolls = list(CTAG_HAND = 20)
 	display_order = JDO_HAND
 	tutorial = "Whether by outstanding merit or petty favoritism, you are the Archduke’s most trusted representative and advisor. Your authority is second only to the Archduke themselves. The weight of your words can shape policy, stir conflict, or silence dissent. Let none forget whose will you carry, and do not fail your benefactor."
-
-"
 	whitelist_req = TRUE
 	give_bank_account = 44
 	noble_income = 22


### PR DESCRIPTION
## About The Pull Request
This PR would allow hands to be young just like other advisors. They can already be any race, and their whole schtick is being chosen by the duke personally and thus having no restrictions.  
It also removes the text implying they have been in service to the duke since childhood. Nobody roleplays this aspect, and I consider it to be needlessly stifling for the role concept.
Instead, you are just the dukes top guy, his chosen representative, for reasons left to you and the duke themselves.
## Testing Evidence
A young kobold hand. Note you could always be a kobold hand, as I said, the only difference being they can now be young.
![h2ikzpu](https://github.com/user-attachments/assets/c777bb35-a807-4868-a02c-dabe2f20dbdd)
## Why It's Good For The Game
Makes sure this important role is more often filled.
I think removing this restriction does not compromise immersion or flavor.
Removes flavor text that was never acted/roleplayed upon and instead brings it in line with how the role is usually played.