### PR TITLE
Partially reverts Night Length changes

### DIFF
--- a/code/controllers/subsystem/nightshift.dm
+++ b/code/controllers/subsystem/nightshift.dm
@@ -8,10 +8,10 @@ SUBSYSTEM_DEF(nightshift)
 	var/current_tod = null
 
 	var/nightshift_active = FALSE
-	var/nightshift_start_time = 756000		//9 PM, 21 Hours
-	var/nightshift_dawn_start = 144000		//4 Hours
-	var/nightshift_day_start = 252000		//7 Hours
-	var/nightshift_dusk_start = 720000		//20 Hours
+	var/nightshift_start_time = 576000	//4pm	//702000=7:30 PM, station time
+	var/nightshift_dawn_start = 288000		//198000=    530am
+	var/nightshift_day_start = 360000		//270000=    730am
+	var/nightshift_dusk_start = 504000		//630000=    530pm
 
 	/* Default STONEKEEP config.
 	var/nightshift_start_time = 756000	//9:00 PM - 2100 hrs

--- a/code/controllers/subsystem/particle_weather_outdoors.dm
+++ b/code/controllers/subsystem/particle_weather_outdoors.dm
@@ -6,32 +6,32 @@
 /datum/time_of_day/dawn
 	name = "Dawn"
 	color = list("#394579", "#49385d", "#3a1537")
-	start = 4 HOURS // 4:00:00 AM
+	start = 8 HOURS //8:00:00 AM
 
 /datum/time_of_day/sunrise
 	name = "Sunrise"
 	color = "#F598AB"
-	start = 6 HOURS  // 6:00:00 AM
+	start = 9.5 HOURS  //9:30:00 AM
 
 /datum/time_of_day/daytime
 	name = "Daytime"
 	color = list("#dbbfbf", "#ddd7bd", "#7a7a77", "#8b8f91", "#ae9dc6", "#d09fbf")
-	start = 7 HOURS // 7:00:00 AM
+	start = 10 HOURS //10:00:00 AM
 
 /datum/time_of_day/sunset
 	name = "Sunset"
 	color = "#ff8a63"
-	start = 18 HOURS // 6:00:00 PM
+	start = 15 HOURS //3:00:00 PM
 
 /datum/time_of_day/dusk
 	name = "Dusk"
 	color = list("#394579", "#49385d", "#302824")
-	start = 20 HOURS // 6:00:00 PM
+	start = 15.5 HOURS //3:30:00 PM
 
 /datum/time_of_day/midnight
 	name = "Midnight" // When to switch to moonlight.
 	color = list("#122325", "#122325", "#122325")	// There is a bug where it cycles through all these possible colors throughout midnight.
-	start = 22 HOURS // 10:00:00 PM		Midnight was at 4 PM. That's why this game is so frskin' dark all the time! Night lighting is now 8 hours, dusk-midnight-dawn. - Nikov
+	start = 16 HOURS //4:00:00 PM	Midnight was at 10:00:00PM. That's why the Antags and Rogues were so freakin' cucked all the time! They didn't have time to antag before being clearly visible in the daylight and being forced to hide and do nothing for half of the dae.
 
 GLOBAL_VAR_INIT(GLOBAL_LIGHT_RANGE, 3)
 GLOBAL_LIST_EMPTY(SUNLIGHT_QUEUE_WORK)   /* turfs to be stateChecked */


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. --> Partial revert of #163 

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->
![image](https://github.com/user-attachments/assets/4b51e686-63fb-4fa0-af86-56ce52c676b5)

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->Night time being significantly shorter meant that antags that can only do their thing at night, like Vampires and WW's, cannot. And instead have to procrastinate or grind for gear throughout the dae instead, for WW's it's significantly worst because the person literally has to hide the whole dae or find their gear and try to blend in, wasting time, knowing they are just gonna turn at night. It even effects regular thieves and bandits, since they struggle to sneak at dae time.
